### PR TITLE
Move details date formatting to utils

### DIFF
--- a/client/src/components/Details/Details.jsx
+++ b/client/src/components/Details/Details.jsx
@@ -3,28 +3,7 @@ import { useNavigate } from "react-router";
 import "./Details.css";
 import ThemeContext from "../../context/ThemeContext";
 import DeleteConfirmationModal from "../DeleteConfirmationModal/DeleteConfirmationModal";
-
-function parseDate(dateString) {
-  if (!dateString) return null;
-  if (dateString.includes("-")) return new Date(dateString);
-
-  const parts = dateString.split(/[./-]/).map((p) => parseInt(p, 10));
-  if (parts.length !== 3) return null;
-
-  const [day, month, year] = parts;
-  return new Date(year, month - 1, day);
-}
-
-function formatDateForInput(dateString) {
-  const date = parseDate(dateString);
-  if (!date) return "";
-
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${day}`;
-}
+import { formatDateForInput } from "../../utils/vehicleDates";
 
 function validateDetailsForm({ revision, bollo, insurance }) {
   const newErrors = {};

--- a/client/src/utils/vehicleDates.js
+++ b/client/src/utils/vehicleDates.js
@@ -42,3 +42,14 @@ export function addExpiryFlags(vehicle) {
     expiring_revision: revision.expiring,
   };
 }
+
+export function formatDateForInput(dateString) {
+  const date = parseDate(dateString);
+  if (!date) return "";
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Cosa cambia

Sposta la formattazione delle date usata nella pagina dettaglio veicolo dentro le utility condivise.

## Dettagli

- Aggiunta `formatDateForInput` in `client/src/utils/vehicleDates.js`
- Rimosse le funzioni locali da `Details.jsx`
- Aggiornato `Details.jsx` per importare la utility condivisa
- Nessun cambio funzionale previsto

## Verifiche

- `npm run lint` OK
- `npm run build` OK