### PR TITLE
Improve dashboard mobile layout

### DIFF
--- a/client/src/components/DashboardSummary/DashboardSummary.css
+++ b/client/src/components/DashboardSummary/DashboardSummary.css
@@ -17,6 +17,12 @@
   color: #222;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
   border-left: 6px solid #4db6ac;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-summary-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.16);
 }
 
 .dashboard-summary-card strong {
@@ -48,14 +54,69 @@ body.dark .dashboard-summary-card {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
 
+body.dark .dashboard-summary-card:hover {
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+}
+
 @media (max-width: 768px) {
   .dashboard-summary {
     grid-template-columns: repeat(2, minmax(140px, 1fr));
+    width: 100%;
+    max-width: 520px;
+    margin: 0.75rem auto 1.25rem;
   }
 }
 
 @media (max-width: 480px) {
   .dashboard-summary {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    padding: 0 0.75rem;
+  }
+
+  .dashboard-summary-card {
+    min-height: 96px;
+    padding: 0.9rem;
+    border-radius: 14px;
+    border-left-width: 5px;
+  }
+
+  .dashboard-summary-card:hover {
+    transform: none;
+  }
+
+  .dashboard-summary-card strong {
+    font-size: 1.8rem;
+  }
+
+  .dashboard-summary-label {
+    font-size: 0.82rem;
+    line-height: 1.25;
+  }
+}
+
+@media (max-width: 360px) {
+  .dashboard-summary {
     grid-template-columns: 1fr;
+  }
+
+  .dashboard-summary-card {
+    min-height: auto;
+    align-items: center;
+    text-align: center;
+    border-left: none;
+    border-top: 5px solid #4db6ac;
+  }
+
+  .dashboard-summary-card--expired {
+    border-top-color: #d32f2f;
+  }
+
+  .dashboard-summary-card--expiring {
+    border-top-color: #f9a825;
+  }
+
+  .dashboard-summary-card--ok {
+    border-top-color: #2e7d32;
   }
 }


### PR DESCRIPTION
## Cosa cambia

- Migliorato il layout mobile della dashboard riepilogativa
- Card riepilogo più leggibili su smartphone
- Layout a 2 colonne sui telefoni più comuni
- Layout a 1 colonna sugli schermi molto stretti
- Numeri e label più ordinati su mobile
- Hover desktop più rifinito
- Hover disattivato su mobile

## Verifiche

- npm run lint OK
- npm run build OK
- git diff --check OK