### PR TITLE
Usa variabile ambiente per l’URL base delle API

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5000/api

--- a/client/src/services/vehiclesApi.js
+++ b/client/src/services/vehiclesApi.js
@@ -1,4 +1,5 @@
-const API_BASE_URL = "http://localhost:5000/api";
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:5000/api";
 
 function toFrontendVehicle(vehicle) {
   return {


### PR DESCRIPTION
## Riepilogo

Questa PR prepara il frontend al futuro deploy del backend, spostando l’URL base delle API in una variabile ambiente Vite.

## Modifiche

- Aggiunto supporto a `VITE_API_BASE_URL` in `vehiclesApi.js`
- Mantenuto `http://localhost:5000/api` come fallback per lo sviluppo locale
- Aggiunto il file `client/.env.example`

## Verifiche

- `git diff --check`
- `npm --prefix client run build`