### PR TITLE
Aumenta limite upload immagine veicolo

### DIFF
--- a/client/src/components/NewVehicle/NewVehicle.jsx
+++ b/client/src/components/NewVehicle/NewVehicle.jsx
@@ -10,7 +10,7 @@ const initialFormData = {
   scadenza_revisione: "",
 };
 
-const maxImageSizeInBytes = 2 * 1024 * 1024;
+const maxImageSizeInBytes = 5 * 1024 * 1024;
 
 function validateVehicleForm(formData) {
   const newErrors = {};
@@ -72,7 +72,7 @@ export default function NewVehicle({ onAdd, onClose }) {
     if (file.size > maxImageSizeInBytes) {
       setErrors({
         ...errors,
-        img_url: "L'immagine è troppo grande. Usa un file massimo di 2 MB.",
+        img_url: "L'immagine è troppo grande. Usa un file massimo di 5 MB.",
       });
       return;
     }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7,7 +7,7 @@ const vehicleRoutes = require("./routes/vehicleRoutes");
 const app = express();
 
 app.use(cors());
-app.use(express.json({ limit: "5mb" }));
+app.use(express.json({ limit: "10mb" }));
 
 app.use("/api/health", healthRoutes);
 app.use("/api/vehicles", vehicleRoutes);


### PR DESCRIPTION
## Riepilogo

Questa PR aumenta il limite massimo per il caricamento dell’immagine veicolo.

## Modifiche

- Aumentato il limite immagine frontend da 2 MB a 5 MB
- Aggiornato il messaggio di errore mostrato all’utente
- Aumentato il limite JSON del backend da 5 MB a 10 MB per supportare immagini convertite in base64

## Note

La soluzione è adatta all’MVP/demo attuale, dove l’immagine viene salvata come base64 su MongoDB.

In futuro sarà preferibile spostare le immagini su un servizio esterno come Cloudinary/S3 e salvare nel database solo l’URL dell’immagine.

## Verifiche

- `git diff --check`
- `npm --prefix client run build`