### PR TITLE
Evita salvataggio immagini veicolo nel localStorage

### DIFF
--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -28,7 +28,6 @@ export default function AppRoutes() {
       const withFlags = apiVehicles.map((v) => addExpiryFlags(v));
 
       setVehicles(withFlags);
-      localStorage.setItem("vehicles", JSON.stringify(withFlags));
     } catch (err) {
       console.error("Errore fetch:", err);
 
@@ -50,12 +49,6 @@ export default function AppRoutes() {
   useEffect(() => {
     fetchVehicles();
   }, [fetchVehicles]);
-
-  useEffect(() => {
-    if (vehicles.length > 0) {
-      localStorage.setItem("vehicles", JSON.stringify(vehicles));
-    }
-  }, [vehicles]);
 
   useEffect(() => {
     const lsDark = JSON.parse(localStorage.getItem("vehicles-dark-mode"));


### PR DESCRIPTION
## Riepilogo

Questa PR risolve l’errore `QuotaExceededError` causato dal salvataggio delle immagini base64 nel localStorage del browser.

## Modifiche

- Rimosso il salvataggio dei veicoli caricati dal backend nel localStorage
- Rimosso il salvataggio automatico dell’array `vehicles` nel localStorage
- Mantenuto il localStorage per il dark mode
- Mantenuta la lettura fallback dei vecchi dati locali quando il backend non è raggiungibile

## Motivo

Ora che My Garage usa il backend Express e MongoDB Atlas, il database deve essere la fonte principale dei dati.

Salvare immagini base64 anche nel localStorage può superare facilmente la quota del browser e causare errore `QuotaExceededError`.

## Verifiche

- `git diff --check`
- `npm --prefix client run build`