### PR TITLE
Allow editing vehicle image from details

### DIFF
--- a/client/src/components/Details/Details.css
+++ b/client/src/components/Details/Details.css
@@ -23,6 +23,66 @@
   margin: 0 auto;
 }
 
+.details-image-placeholder {
+  width: 100%;
+  max-width: 250px;
+  min-height: 160px;
+  border: 2px dashed #c8d0d8;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  color: #6c757d;
+  background: rgba(108, 117, 125, 0.08);
+  margin: 0 auto;
+}
+
+.details-image-placeholder span {
+  font-size: 2rem;
+}
+
+.details-image-placeholder p {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.details-image-upload {
+  gap: 0.45rem;
+}
+
+.details-image-upload small {
+  width: 80%;
+  max-width: 250px;
+  color: #6c757d;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.details-image-upload input[type="file"] {
+  cursor: pointer;
+}
+
+.details-remove-image {
+  width: 80%;
+  max-width: 250px;
+  padding: 0.55rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid #dc3545;
+  background: transparent;
+  color: #dc3545;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.details-remove-image:hover {
+  background: rgba(220, 53, 69, 0.1);
+  transform: translateY(-1px);
+}
+
 .input-group {
   width: 100%;
   display: flex;
@@ -54,6 +114,25 @@ body.dark .input-group input {
   background-color: #3c3c50;
   color: #f5f5f5;
   border: 1px solid #555;
+}
+
+body.dark .details-image-placeholder {
+  border-color: #555;
+  color: #d0d0d0;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+body.dark .details-image-upload small {
+  color: #d0d0d0;
+}
+
+body.dark .details-remove-image {
+  border-color: #ff8a80;
+  color: #ff8a80;
+}
+
+body.dark .details-remove-image:hover {
+  background: rgba(255, 138, 128, 0.12);
 }
 
 /* CONTENITORE PULSANTI */
@@ -137,6 +216,15 @@ body.dark .details-actions .btn-delete:hover {
   font-weight: 600;
 }
 
+.details-saving-message {
+  margin: 1rem 0;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  color: #0d6efd;
+  background: rgba(13, 110, 253, 0.12);
+  font-weight: 600;
+}
+
 @media (max-width: 600px) {
   .card-details {
     width: calc(100% - 2rem);
@@ -153,47 +241,67 @@ body.dark .details-actions .btn-delete:hover {
     object-fit: contain;
   }
 
-  .input-group {
+  .details-image-placeholder {
+  max-width: 100%;
+  min-height: 150px;
+}
+
+.details-image-upload small,
+.details-remove-image {
+  width: 100%;
+  max-width: none;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+.input-group {
     align-items: stretch;
     text-align: left;
     margin-bottom: 0.95rem;
-  }
+}
 
-  .input-group label {
+.input-group label {
     margin-bottom: 0.4rem;
     font-size: 0.95rem;
-  }
+}
 
-  .input-group input {
+.input-group input {
     width: 100%;
     max-width: none;
     box-sizing: border-box;
     padding: 0.75rem 0.85rem;
     font-size: 1rem;
-  }
+}
 
-  .details-actions {
+.details-actions {
     flex-direction: column;
     gap: 0.75rem;
     margin-top: 1rem;
-  }
+}
 
-  .details-actions button {
+.details-actions button {
     width: 100%;
     padding: 0.8rem 1rem;
     font-size: 1rem;
-  }
+}
 
-  .field-error {
+.field-error {
     font-size: 0.82rem;
-  }
+}
 
-  .details-success-message {
+.details-success-message {
     width: 100%;
     box-sizing: border-box;
     margin: 0.75rem 0;
     font-size: 0.95rem;
-  }
+}
+
+.details-saving-message {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0.75rem 0;
+  font-size: 0.95rem;
+}
 }
 
 @media (max-width: 380px) {
@@ -205,4 +313,8 @@ body.dark .details-actions .btn-delete:hover {
   .card-details img {
     max-height: 180px;
   }
+
+  .details-image-placeholder {
+  min-height: 130px;
+}
 }

--- a/client/src/components/Details/Details.jsx
+++ b/client/src/components/Details/Details.jsx
@@ -5,6 +5,8 @@ import ThemeContext from "../../context/ThemeContext";
 import DeleteConfirmationModal from "../DeleteConfirmationModal/DeleteConfirmationModal";
 import { formatDateForInput } from "../../utils/vehicleDates";
 
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
 function validateDetailsForm({ revision, bollo, insurance }) {
   const newErrors = {};
 
@@ -23,6 +25,16 @@ function validateDetailsForm({ revision, bollo, insurance }) {
   return newErrors;
 }
 
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Errore durante la lettura del file."));
+    reader.readAsDataURL(file);
+  });
+}
+
 export default function Details({ vehicle, onUpdate, onDelete }) {
   const { isDarkMode } = useContext(ThemeContext);
   const navigate = useNavigate();
@@ -32,17 +44,23 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
   const [insurance, setInsurance] = useState(
     vehicle.scadenza_assicurazione || ""
   );
+  const [imagePreview, setImagePreview] = useState(vehicle.img_url || "");
   const [errors, setErrors] = useState({});
+  const [imageError, setImageError] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     setRevision(vehicle.scadenza_revisione || "");
     setBollo(vehicle.scadenza_bollo || "");
     setInsurance(vehicle.scadenza_assicurazione || "");
+    setImagePreview(vehicle.img_url || "");
     setErrors({});
+    setImageError("");
     setSuccessMessage("");
     setShowDeleteModal(false);
+    setIsSaving(false);
   }, [vehicle]);
 
   const handleFieldChange = (fieldName, value) => {
@@ -68,6 +86,43 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
     }
   };
 
+  const handleImageChange = async (event) => {
+    const file = event.target.files?.[0];
+
+    setSuccessMessage("");
+    setImageError("");
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      setImageError("Seleziona un file immagine valido.");
+      event.target.value = "";
+      return;
+    }
+
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      setImageError("L'immagine non può superare i 5 MB.");
+      event.target.value = "";
+      return;
+    }
+
+    try {
+      const imageDataUrl = await readFileAsDataUrl(file);
+      setImagePreview(imageDataUrl);
+    } catch {
+      setImageError("Non è stato possibile caricare l'immagine.");
+      event.target.value = "";
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setImagePreview("");
+    setImageError("");
+    setSuccessMessage("");
+  };
+
   const handleRenew = () => {
     const validationErrors = validateDetailsForm({
       revision,
@@ -81,15 +136,26 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
       return;
     }
 
+    if (imageError) {
+      setSuccessMessage("");
+      return;
+    }
+
     const updatedVehicle = {
       ...vehicle,
+      img_url: imagePreview,
       scadenza_revisione: revision,
       scadenza_bollo: bollo,
       scadenza_assicurazione: insurance,
     };
 
-    onUpdate(updatedVehicle);
-    setSuccessMessage("✅ Scadenze aggiornate correttamente.");
+    setIsSaving(true);
+
+    onUpdate(updatedVehicle).catch(() => {
+      console.error("Errore durante il salvataggio delle modifiche.");
+    });
+
+    navigate("/", { replace: true });
   };
 
   const openDeleteModal = () => {
@@ -112,11 +178,43 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
           {vehicle.brand} {vehicle.model}
         </h2>
 
-        <img src={vehicle.img_url} alt={vehicle.model} />
+        {imagePreview ? (
+          <img src={imagePreview} alt={vehicle.model} />
+        ) : (
+          <div className="details-image-placeholder">
+            <span>🚗</span>
+            <p>Nessuna foto disponibile</p>
+          </div>
+        )}
+
+        <div className="input-group details-image-upload">
+          <label htmlFor="vehicle-image">Foto veicolo:</label>
+          <input
+            id="vehicle-image"
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+          />
+          <small>Puoi caricare o sostituire la foto. Dimensione massima: 5 MB.</small>
+
+          {imagePreview && (
+            <button
+              type="button"
+              className="details-remove-image"
+              onClick={handleRemoveImage}
+            >
+              Rimuovi foto
+            </button>
+          )}
+
+          {imageError && <span className="field-error">{imageError}</span>}
+        </div>
 
         {successMessage && (
           <p className="details-success-message">{successMessage}</p>
         )}
+
+        {errors.submit && <p className="field-error">{errors.submit}</p>}
 
         <div className="input-group">
           <label>Scadenza Revisione:</label>
@@ -156,7 +254,9 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
         </div>
 
         <div className="details-actions">
-          <button onClick={handleRenew}>💾 Salva modifiche</button>
+          <button onClick={handleRenew} disabled={isSaving}>
+            {isSaving ? "Salvataggio..." : "💾 Salva modifiche"}
+          </button>
           <button onClick={openDeleteModal} className="btn-delete">
             🗑️ Elimina
           </button>

--- a/client/src/components/Vehicle/Vehicle.css
+++ b/client/src/components/Vehicle/Vehicle.css
@@ -158,3 +158,25 @@
     top: 210px;
   }
 }
+
+.vehicle-image-placeholder {
+  width: 100%;
+  min-height: 150px;
+  border-radius: 12px;
+  background: rgba(108, 117, 125, 0.1);
+  border: 2px dashed #c8d0d8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6c757d;
+}
+
+.vehicle-image-placeholder span {
+  font-size: 2.5rem;
+}
+
+body.dark .vehicle-image-placeholder {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: #555;
+  color: #d0d0d0;
+}

--- a/client/src/components/Vehicle/Vehicle.jsx
+++ b/client/src/components/Vehicle/Vehicle.jsx
@@ -36,7 +36,13 @@ export default function Vehicle({ vehicle }) {
         </div>
 
         <div className="card-traffic-img-light">
-          <img src={vehicle.img_url} alt={vehicle.model} />
+          {vehicle.img_url ? (
+            <img src={vehicle.img_url} alt={`${vehicle.brand} ${vehicle.model}`} />
+          ) : (
+            <div className="vehicle-image-placeholder">
+              <span>🚗</span>
+            </div>
+          )}
 
           <div className="traffic-light" aria-label={`Stato veicolo: ${vehicleStatus}`}>
             <span className={`traffic-dot traffic-dot-red ${vehicleStatus === 'red' ? 'active' : ''}`}></span>

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -13,6 +13,14 @@ import {
   updateVehicle,
 } from "../services/vehiclesApi";
 
+function getVehicleId(vehicle) {
+  return vehicle.id || vehicle._id;
+}
+
+function isSameVehicle(vehicleA, vehicleB) {
+  return getVehicleId(vehicleA)?.toString() === getVehicleId(vehicleB)?.toString();
+}
+
 export default function AppRoutes() {
   const [vehicles, setVehicles] = useState([]);
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -25,7 +33,7 @@ export default function AppRoutes() {
 
     try {
       const apiVehicles = await getVehicles();
-      const withFlags = apiVehicles.map((v) => addExpiryFlags(v));
+      const withFlags = apiVehicles.map((vehicle) => addExpiryFlags(vehicle));
 
       setVehicles(withFlags);
     } catch (err) {
@@ -65,29 +73,46 @@ export default function AppRoutes() {
       const createdVehicle = await createVehicle(newVehicle);
       const vehicleWithFlags = addExpiryFlags(createdVehicle);
 
-      setVehicles((prev) => [...prev, vehicleWithFlags]);
+      setVehicles((prevVehicles) => [...prevVehicles, vehicleWithFlags]);
       setError("");
     } catch (err) {
       console.error("Errore creazione veicolo:", err);
       setError("Non riesco ad aggiungere il veicolo. Riprova più tardi.");
+      throw err;
     }
   };
 
   const handleUpdateVehicle = async (updatedVehicle) => {
+    const optimisticVehicle = addExpiryFlags(updatedVehicle);
+
+    setVehicles((prevVehicles) =>
+      prevVehicles.map((vehicle) =>
+        isSameVehicle(vehicle, optimisticVehicle) ? optimisticVehicle : vehicle
+      )
+    );
+
     try {
       const savedVehicle = await updateVehicle(
-        updatedVehicle.id,
+        getVehicleId(updatedVehicle),
         updatedVehicle
       );
+
       const vehicleWithFlags = addExpiryFlags(savedVehicle);
 
-      setVehicles((prev) =>
-        prev.map((v) => (v.id === vehicleWithFlags.id ? vehicleWithFlags : v))
+      setVehicles((prevVehicles) =>
+        prevVehicles.map((vehicle) =>
+          isSameVehicle(vehicle, vehicleWithFlags) ? vehicleWithFlags : vehicle
+        )
       );
+
       setError("");
+      return vehicleWithFlags;
     } catch (err) {
       console.error("Errore aggiornamento veicolo:", err);
       setError("Non riesco ad aggiornare il veicolo. Riprova più tardi.");
+
+      await fetchVehicles();
+      throw err;
     }
   };
 
@@ -95,11 +120,17 @@ export default function AppRoutes() {
     try {
       await deleteVehicle(vehicleId);
 
-      setVehicles((prev) => prev.filter((v) => v.id !== vehicleId));
+      setVehicles((prevVehicles) =>
+        prevVehicles.filter(
+          (vehicle) => getVehicleId(vehicle)?.toString() !== vehicleId.toString()
+        )
+      );
+
       setError("");
     } catch (err) {
       console.error("Errore eliminazione veicolo:", err);
       setError("Non riesco a eliminare il veicolo. Riprova più tardi.");
+      throw err;
     }
   };
 
@@ -107,6 +138,7 @@ export default function AppRoutes() {
     <ThemeContext.Provider value={{ isDarkMode, setIsDarkMode }}>
       <BrowserRouter>
         <Menu title="My Garage" onAddVehicle={handleAddVehicle} />
+
         <div className="main-content">
           <Routes>
             <Route
@@ -128,10 +160,10 @@ export default function AppRoutes() {
               element={
                 <App
                   vehicles={vehicles.filter(
-                    (v) =>
-                      v.expired_car_tax ||
-                      v.expired_insurance ||
-                      v.expired_revision
+                    (vehicle) =>
+                      vehicle.expired_car_tax ||
+                      vehicle.expired_insurance ||
+                      vehicle.expired_revision
                   )}
                   isLoading={isLoading}
                   error={error}
@@ -146,10 +178,10 @@ export default function AppRoutes() {
               element={
                 <App
                   vehicles={vehicles.filter(
-                    (v) =>
-                      v.expiring_car_tax ||
-                      v.expiring_insurance ||
-                      v.expiring_revision
+                    (vehicle) =>
+                      vehicle.expiring_car_tax ||
+                      vehicle.expiring_insurance ||
+                      vehicle.expiring_revision
                   )}
                   isLoading={isLoading}
                   error={error}
@@ -183,7 +215,10 @@ export default function AppRoutes() {
 
 function DetailsWrapper({ vehicles, onUpdate, onDelete }) {
   const { id } = useParams();
-  const vehicle = vehicles.find((v) => v.id.toString() === id.toString());
+
+  const vehicle = vehicles.find(
+    (item) => getVehicleId(item)?.toString() === id.toString()
+  );
 
   return vehicle ? (
     <Details vehicle={vehicle} onUpdate={onUpdate} onDelete={onDelete} />


### PR DESCRIPTION
## Riepilogo

- Aggiunto il supporto per caricare o modificare la foto dalla pagina dettaglio veicolo
- Aggiunta anteprima immagine nel dettaglio
- Aggiunta azione per rimuovere la foto esistente
- Aggiunta validazione immagine con limite massimo di 5 MB
- Aggiunto placeholder quando un veicolo non ha una foto
- Evitato il rendering di immagini con `src` vuoto nelle card veicolo
- Migliorato il flusso di aggiornamento con update ottimistico della UI
- Dopo il salvataggio, l’utente viene riportato automaticamente alla Home

## Test

- [x] Creato veicolo senza foto
- [x] Verificato placeholder quando il veicolo non ha immagine
- [x] Aggiunta foto dalla pagina dettaglio
- [x] Verificato aggiornamento immediato della card in Home
- [x] Verificata persistenza della foto dopo refresh
- [x] Rimossa foto dalla pagina dettaglio
- [x] Verificato ritorno del placeholder dopo rimozione foto
- [x] Verificato messaggio di errore con immagine sopra 5 MB
- [x] Verificato ritorno automatico alla Home dopo il salvataggio
- [x] `npm --prefix client run build`
- [x] `git diff --check`