### PR TITLE
Restringe le origini CORS del backend

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -6,7 +6,24 @@ const vehicleRoutes = require("./routes/vehicleRoutes");
 
 const app = express();
 
-app.use(cors());
+const allowedOrigins = [
+  "https://my-garage-expiration.netlify.app",
+  "http://localhost:5173",
+];
+
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error("Not allowed by CORS"));
+    },
+  })
+);
+
 app.use(express.json({ limit: "10mb" }));
 
 app.use("/api/health", healthRoutes);


### PR DESCRIPTION
## Riepilogo

- Sostituita la configurazione CORS aperta con una lista di origini consentite.
- Consentite le richieste dal frontend Netlify.
- Consentite le richieste da `localhost:5173` per lo sviluppo locale.
- Mantenute abilitate le richieste senza origin, utili per health check, curl, Postman o test diretti.

## Origini consentite

- `https://my-garage-expiration.netlify.app`
- `http://localhost:5173`

## Verifiche

- [x] `git diff --check`
- [x] backend avviato correttamente
- [x] `npm --prefix client run build`
- [x] frontend avviato correttamente