### PR TITLE
Migliora feedback delle azioni sui form

### DIFF
--- a/client/src/components/Details/Details.jsx
+++ b/client/src/components/Details/Details.jsx
@@ -123,7 +123,7 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
     setSuccessMessage("");
   };
 
-  const handleRenew = () => {
+  const handleRenew = async () => {
     const validationErrors = validateDetailsForm({
       revision,
       bollo,
@@ -150,12 +150,20 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
     };
 
     setIsSaving(true);
+    setErrors((prevErrors) => ({ ...prevErrors, submit: "" }));
 
-    onUpdate(updatedVehicle).catch(() => {
-      console.error("Errore durante il salvataggio delle modifiche.");
-    });
-
-    navigate("/", { replace: true });
+    try {
+      await onUpdate(updatedVehicle);
+      navigate("/", { replace: true });
+    } catch {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        submit:
+          "Non è stato possibile salvare le modifiche. Controlla la connessione e riprova.",
+      }));
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const openDeleteModal = () => {
@@ -166,9 +174,20 @@ export default function Details({ vehicle, onUpdate, onDelete }) {
     setShowDeleteModal(false);
   };
 
-  const confirmDelete = () => {
-    onDelete(vehicle.id);
-    navigate("/");
+  const confirmDelete = async () => {
+    setErrors((prevErrors) => ({ ...prevErrors, submit: "" }));
+
+    try {
+      await onDelete(vehicle.id);
+      navigate("/");
+    } catch {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        submit:
+          "Non è stato possibile eliminare il veicolo. Controlla la connessione e riprova.",
+      }));
+      setShowDeleteModal(false);
+    }
   };
 
   return (

--- a/client/src/components/NewVehicle/NewVehicle.css
+++ b/client/src/components/NewVehicle/NewVehicle.css
@@ -208,3 +208,11 @@
   height: auto;
   object-fit: cover;
 }
+
+.form-error {
+  margin: 0.75rem 0 0;
+  color: #dc3545;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.4;
+}

--- a/client/src/components/NewVehicle/NewVehicle.jsx
+++ b/client/src/components/NewVehicle/NewVehicle.jsx
@@ -43,11 +43,14 @@ export default function NewVehicle({ onAdd, onClose }) {
   const [formData, setFormData] = useState(initialFormData);
   const [errors, setErrors] = useState({});
   const [imagePreview, setImagePreview] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   function handleChange(e) {
     const { name, value } = e.target;
 
     setFormData({ ...formData, [name]: value });
+    setSubmitError("");
 
     if (errors[name]) {
       setErrors({ ...errors, [name]: "" });
@@ -97,25 +100,37 @@ export default function NewVehicle({ onAdd, onClose }) {
     reader.readAsDataURL(file);
   }
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault();
 
     const validationErrors = validateVehicleForm(formData);
 
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
+      setSubmitError("");
       return;
     }
 
-    onAdd({
-      ...formData,
-      brand: formData.brand.trim(),
-      model: formData.model.trim(),
-      img_url: formData.img_url.trim(),
-      id: Date.now(),
-    });
+    setIsSubmitting(true);
+    setSubmitError("");
 
-    onClose();
+    try {
+      await onAdd({
+        ...formData,
+        brand: formData.brand.trim(),
+        model: formData.model.trim(),
+        img_url: formData.img_url.trim(),
+        id: Date.now(),
+      });
+
+      onClose();
+    } catch {
+      setSubmitError(
+        "Non è stato possibile aggiungere il veicolo. Controlla la connessione e riprova."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -209,9 +224,12 @@ export default function NewVehicle({ onAdd, onClose }) {
           )}
         </label>
 
+        {submitError && <p className="form-error">{submitError}</p>}
         <div className="form-actions">
-          <button type="submit">Conferma</button>
-          <button type="button" onClick={onClose}>
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Salvataggio..." : "Conferma"}
+          </button>
+          <button type="button" onClick={onClose} disabled={isSubmitting}>
             Annulla
           </button>
         </div>


### PR DESCRIPTION
## Riepilogo

- Migliorato il feedback durante l’aggiunta di un nuovo veicolo.
- Il form di aggiunta ora attende il completamento del salvataggio prima di chiudersi.
- Aggiunto stato di salvataggio con pulsanti disabilitati durante l’invio.
- Aggiunto messaggio di errore visibile se l’aggiunta del veicolo fallisce.
- Migliorata la gestione del salvataggio modifiche nella pagina dettaglio.
- La pagina dettaglio torna alla Home solo dopo un salvataggio completato correttamente.
- Migliorata la gestione errore in caso di eliminazione fallita.
- Aggiunto stile dedicato per gli errori generali del form.

## Verifiche

- [x] `git diff --check`
- [x] `npm --prefix client run build`