### PR TITLE
Aggiunge notifiche globali toast

### DIFF
--- a/client/src/components/Toast/Toast.css
+++ b/client/src/components/Toast/Toast.css
@@ -1,0 +1,94 @@
+.toast {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1000;
+  max-width: 360px;
+  width: calc(100% - 2rem);
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  animation: toast-slide-in 0.25s ease-out;
+}
+
+.toast-success {
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+}
+
+.toast-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.toast-info {
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+}
+
+.toast-content strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.toast-content p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.toast-close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-theme="dark"] .toast-success {
+  background: #052e24;
+  color: #bbf7d0;
+  border-color: #047857;
+}
+
+[data-theme="dark"] .toast-error {
+  background: #450a0a;
+  color: #fecaca;
+  border-color: #b91c1c;
+}
+
+[data-theme="dark"] .toast-info {
+  background: #172554;
+  color: #bfdbfe;
+  border-color: #2563eb;
+}
+
+@media (max-width: 600px) {
+  .toast {
+    right: 1rem;
+    bottom: 1rem;
+    max-width: none;
+  }
+}

--- a/client/src/components/Toast/Toast.jsx
+++ b/client/src/components/Toast/Toast.jsx
@@ -1,0 +1,27 @@
+import "./Toast.css";
+
+function Toast({ toast, onClose }) {
+  if (!toast) {
+    return null;
+  }
+
+  return (
+    <div className={`toast toast-${toast.type}`} role="status" aria-live="polite">
+      <div className="toast-content">
+        <strong>{toast.title}</strong>
+        {toast.message && <p>{toast.message}</p>}
+      </div>
+
+      <button
+        type="button"
+        className="toast-close"
+        onClick={onClose}
+        aria-label="Chiudi notifica"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export default Toast;

--- a/client/src/context/ToastContext.jsx
+++ b/client/src/context/ToastContext.jsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import Toast from "../components/Toast/Toast";
+
+const ToastContext = createContext(null);
+
+export function ToastProvider({ children }) {
+  const [toast, setToast] = useState(null);
+
+  const showToast = ({ type = "info", title, message = "" }) => {
+    setToast({
+      id: Date.now(),
+      type,
+      title,
+      message,
+    });
+  };
+
+  const hideToast = () => {
+    setToast(null);
+  };
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setToast(null);
+    }, 3500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [toast]);
+
+  const value = useMemo(
+    () => ({
+      showToast,
+      hideToast,
+    }),
+    []
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Toast toast={toast} onClose={hideToast} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used inside ToastProvider");
+  }
+
+  return context;
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,9 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import AppRoutes from './routes/AppRoutes.jsx'
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import { ToastProvider } from "./context/ToastContext.jsx";
+import AppRoutes from "./routes/AppRoutes.jsx";
 
-createRoot(document.getElementById('root')).render(
-  //  <StrictMode>
-    <AppRoutes/>
-  // </StrictMode>,
-)
+createRoot(document.getElementById("root")).render(
+  <ToastProvider>
+    <AppRoutes />
+  </ToastProvider>
+);

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -1,3 +1,4 @@
+import { useToast } from "../context/ToastContext";
 import { addExpiryFlags } from "../utils/vehicleDates";
 import { BrowserRouter, Route, Routes, useParams } from "react-router";
 import App from "../App";
@@ -27,6 +28,7 @@ export default function AppRoutes() {
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState("");
+  const { showToast } = useToast();
 
   const fetchVehicles = useCallback(async () => {
     setIsLoading(true);
@@ -77,6 +79,11 @@ export default function AppRoutes() {
       const vehicleWithFlags = addExpiryFlags(createdVehicle);
 
       setVehicles((prevVehicles) => [...prevVehicles, vehicleWithFlags]);
+      showToast({
+        type: "success",
+        title: "Veicolo aggiunto",
+        message: "Il veicolo è stato salvato correttamente.",
+      });
       setError("");
     } catch (err) {
       console.error("Errore creazione veicolo:", err);
@@ -93,6 +100,12 @@ export default function AppRoutes() {
         isSameVehicle(vehicle, optimisticVehicle) ? optimisticVehicle : vehicle
       )
     );
+
+    showToast({
+      type: "success",
+      title: "Modifiche salvate",
+      message: "Le informazioni del veicolo sono state aggiornate.",
+    });
 
     try {
       const savedVehicle = await updateVehicle(
@@ -128,6 +141,12 @@ export default function AppRoutes() {
           (vehicle) => getVehicleId(vehicle)?.toString() !== vehicleId.toString()
         )
       );
+
+      showToast({
+        type: "success",
+        title: "Veicolo eliminato",
+        message: "Il veicolo è stato rimosso correttamente.",
+      });
 
       setError("");
     } catch (err) {


### PR DESCRIPTION
## Riepilogo

Aggiunta di un sistema di notifiche globali toast per migliorare il feedback utente dopo le principali azioni sui veicoli.

## Modifiche principali

- aggiunto componente riutilizzabile `Toast`
- aggiunto `ToastContext` con funzione globale `showToast`
- avvolta l’app con `ToastProvider`
- aggiunte notifiche di successo dopo:
  - aggiunta veicolo
  - modifica veicolo
  - eliminazione veicolo
- aggiunto stile responsive per le notifiche
- aggiunto supporto dark mode per i toast

## Verifiche

- [x] `git diff --check`
- [x] `npm --prefix client run build`