### PR TITLE
Aggiunge base frontend per autenticazione utenti

### DIFF
--- a/client/src/components/Auth/AuthForm.css
+++ b/client/src/components/Auth/AuthForm.css
@@ -1,0 +1,153 @@
+.auth-page {
+  min-height: calc(100vh - 80px);
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+}
+
+.auth-card {
+  width: min(100%, 430px);
+  background: var(--card-bg, #ffffff);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.auth-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  margin-bottom: 0.75rem;
+  border-radius: 18px;
+  background: #eff6ff;
+  font-size: 1.8rem;
+}
+
+.auth-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.auth-header p {
+  margin: 0.5rem 0 0;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-form label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 700;
+  color: #334155;
+}
+
+.auth-form input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid #cbd5e1;
+  font: inherit;
+  background: #ffffff;
+  color: #0f172a;
+}
+
+.auth-form input:focus {
+  outline: 2px solid #93c5fd;
+  border-color: #2563eb;
+}
+
+.auth-form input:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.auth-form button,
+.auth-switch button {
+  font: inherit;
+}
+
+.auth-form button[type="submit"] {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.2rem;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.auth-form button[type="submit"]:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.auth-error {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  background: #fef2f2;
+  color: #991b1b;
+  font-weight: 700;
+}
+
+.auth-switch {
+  margin: 1.2rem 0 0;
+  text-align: center;
+  color: #64748b;
+}
+
+.auth-switch button {
+  border: none;
+  background: transparent;
+  color: #2563eb;
+  font-weight: 800;
+  cursor: pointer;
+  padding: 0;
+}
+
+body.dark .auth-card {
+  background: #111827;
+  border-color: #334155;
+}
+
+body.dark .auth-header p,
+body.dark .auth-switch {
+  color: #cbd5e1;
+}
+
+body.dark .auth-form label {
+  color: #e5e7eb;
+}
+
+body.dark .auth-form input {
+  background: #020617;
+  border-color: #475569;
+  color: #f8fafc;
+}
+
+body.dark .auth-icon {
+  background: #1e3a8a;
+}
+
+@media (max-width: 520px) {
+  .auth-card {
+    padding: 1.4rem;
+    border-radius: 20px;
+  }
+
+  .auth-header h1 {
+    font-size: 1.5rem;
+  }
+}

--- a/client/src/components/Auth/AuthForm.jsx
+++ b/client/src/components/Auth/AuthForm.jsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import "./AuthForm.css";
+
+function AuthForm({
+  title,
+  description,
+  submitLabel,
+  isRegister = false,
+  onSubmit,
+  switchText,
+  switchActionLabel,
+  onSwitch,
+}) {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    password: "",
+  });
+  const [formError, setFormError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      [name]: value,
+    }));
+
+    setFormError("");
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (isRegister && !formData.name.trim()) {
+      setFormError("Inserisci il nome.");
+      return;
+    }
+
+    if (!formData.email.trim()) {
+      setFormError("Inserisci l'email.");
+      return;
+    }
+
+    if (!formData.password.trim()) {
+      setFormError("Inserisci la password.");
+      return;
+    }
+
+    if (formData.password.length < 6) {
+      setFormError("La password deve contenere almeno 6 caratteri.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await onSubmit(formData);
+    } catch (error) {
+      setFormError(error.message || "Operazione non riuscita. Riprova.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="auth-page">
+      <div className="auth-card">
+        <div className="auth-header">
+          <span className="auth-icon">🚗</span>
+          <h1>{title}</h1>
+          <p>{description}</p>
+        </div>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          {isRegister && (
+            <label>
+              Nome
+              <input
+                type="text"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                placeholder="Il tuo nome"
+                disabled={isSubmitting}
+              />
+            </label>
+          )}
+
+          <label>
+            Email
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              placeholder="email@example.com"
+              disabled={isSubmitting}
+            />
+          </label>
+
+          <label>
+            Password
+            <input
+              type="password"
+              name="password"
+              value={formData.password}
+              onChange={handleChange}
+              placeholder="Almeno 6 caratteri"
+              disabled={isSubmitting}
+            />
+          </label>
+
+          {formError && <p className="auth-error">{formError}</p>}
+
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? "Attendere..." : submitLabel}
+          </button>
+        </form>
+
+        <p className="auth-switch">
+          {switchText}{" "}
+          <button type="button" onClick={onSwitch}>
+            {switchActionLabel}
+          </button>
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default AuthForm;

--- a/client/src/components/Auth/Login.jsx
+++ b/client/src/components/Auth/Login.jsx
@@ -1,0 +1,36 @@
+import { useNavigate } from "react-router";
+import { useAuth } from "../../context/AuthContext";
+import { useToast } from "../../context/ToastContext";
+import AuthForm from "./AuthForm";
+
+function Login() {
+  const { login } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const handleLogin = async ({ email, password }) => {
+    await login({ email, password });
+
+    showToast({
+      type: "success",
+      title: "Accesso effettuato",
+      message: "Bentornato in My Garage.",
+    });
+
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <AuthForm
+      title="Accedi"
+      description="Entra nel tuo garage personale e gestisci le scadenze dei veicoli."
+      submitLabel="Accedi"
+      onSubmit={handleLogin}
+      switchText="Non hai ancora un account?"
+      switchActionLabel="Registrati"
+      onSwitch={() => navigate("/register")}
+    />
+  );
+}
+
+export default Login;

--- a/client/src/components/Auth/Register.jsx
+++ b/client/src/components/Auth/Register.jsx
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router";
+import { useAuth } from "../../context/AuthContext";
+import { useToast } from "../../context/ToastContext";
+import AuthForm from "./AuthForm";
+
+function Register() {
+  const { register } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const handleRegister = async ({ name, email, password }) => {
+    await register({ name, email, password });
+
+    showToast({
+      type: "success",
+      title: "Registrazione completata",
+      message: "Il tuo account My Garage è stato creato.",
+    });
+
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <AuthForm
+      title="Crea account"
+      description="Crea il tuo profilo per iniziare a gestire i veicoli in modo personale."
+      submitLabel="Registrati"
+      isRegister
+      onSubmit={handleRegister}
+      switchText="Hai già un account?"
+      switchActionLabel="Accedi"
+      onSwitch={() => navigate("/login")}
+    />
+  );
+}
+
+export default Register;

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,74 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { loginUser, registerUser } from "../services/authApi";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [auth, setAuth] = useState({
+    user: null,
+    token: "",
+  });
+
+  useEffect(() => {
+    const storedAuth = localStorage.getItem("my-garage-auth");
+
+    if (storedAuth) {
+      setAuth(JSON.parse(storedAuth));
+    }
+  }, []);
+
+  const saveAuth = (authData) => {
+    const nextAuth = {
+      user: authData.user,
+      token: authData.token,
+    };
+
+    setAuth(nextAuth);
+    localStorage.setItem("my-garage-auth", JSON.stringify(nextAuth));
+  };
+
+  const register = async (userData) => {
+    const result = await registerUser(userData);
+    saveAuth(result);
+    return result;
+  };
+
+  const login = async (credentials) => {
+    const result = await loginUser(credentials);
+    saveAuth(result);
+    return result;
+  };
+
+  const logout = () => {
+    setAuth({
+      user: null,
+      token: "",
+    });
+
+    localStorage.removeItem("my-garage-auth");
+  };
+
+  const value = useMemo(
+    () => ({
+      user: auth.user,
+      token: auth.token,
+      isAuthenticated: Boolean(auth.token),
+      register,
+      login,
+      logout,
+    }),
+    [auth]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+
+  return context;
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,9 +2,12 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { ToastProvider } from "./context/ToastContext.jsx";
 import AppRoutes from "./routes/AppRoutes.jsx";
+import { AuthProvider } from "./context/AuthContext.jsx";
 
 createRoot(document.getElementById("root")).render(
-  <ToastProvider>
-    <AppRoutes />
-  </ToastProvider>
+  <AuthProvider>
+    <ToastProvider>
+      <AppRoutes />
+    </ToastProvider>
+  </AuthProvider>
 );

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -14,6 +14,8 @@ import {
   getVehicles,
   updateVehicle,
 } from "../services/vehiclesApi";
+import Login from "../components/Auth/Login";
+import Register from "../components/Auth/Register";
 
 function getVehicleId(vehicle) {
   return vehicle.id || vehicle._id;
@@ -210,6 +212,10 @@ export default function AppRoutes() {
 
         <div className="main-content">
           <Routes>
+
+            <Route path="login" element={<Login />} />
+            <Route path="register" element={<Register />} />
+
             <Route
               path="/"
               element={

--- a/client/src/services/authApi.js
+++ b/client/src/services/authApi.js
@@ -1,0 +1,28 @@
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:5000/api";
+
+async function requestAuth(endpoint, data) {
+  const response = await fetch(`${API_BASE_URL}/auth/${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+
+  const result = await response.json();
+
+  if (!response.ok) {
+    throw new Error(result.message || "Errore durante l'autenticazione.");
+  }
+
+  return result;
+}
+
+export function registerUser(userData) {
+  return requestAuth("register", userData);
+}
+
+export function loginUser(credentials) {
+  return requestAuth("login", credentials);
+}


### PR DESCRIPTION
## Riepilogo

Aggiunta della base frontend per autenticazione utenti.

## Modifiche principali

- aggiunto servizio `authApi`
- aggiunto `AuthContext`
- aggiunto `AuthProvider`
- salvataggio di token e utente in localStorage
- aggiunta pagina Login
- aggiunta pagina Register
- aggiunto componente riutilizzabile `AuthForm`
- aggiunte rotte `/login` e `/register`
- aggiunti toast di successo dopo login e registrazione

## Test manuali

- pagina `/register` raggiungibile
- pagina `/login` raggiungibile
- registrazione utente completata correttamente
- login utente completato correttamente
- token e utente salvati in localStorage
- redirect alla Home dopo login/registrazione

## Verifiche

- [x] `git diff --check`
- [x] `npm --prefix client run build`