### PR TITLE
Aggiunge login, registrazione e logout nel menu

### DIFF
--- a/client/src/components/Menu/Menu.css
+++ b/client/src/components/Menu/Menu.css
@@ -44,3 +44,66 @@ body.dark .menu {
   gap: 1rem;
   margin-top: 1rem;
 }
+
+.menu-user {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 120px;
+  padding: 0.45rem 0.8rem;
+  border-radius: 14px;
+  background: rgba(77, 182, 172, 0.14);
+  color: #00695c;
+  line-height: 1.2;
+}
+
+.menu-user-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.75;
+}
+
+.menu-user strong {
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.menu-logout {
+  background: #ef4444;
+  color: #ffffff;
+}
+
+.menu-logout:hover {
+  background: #dc2626;
+}
+
+body.dark .menu-user {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ccfbf1;
+}
+
+@media (max-width: 720px) {
+  .menu {
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .menu li a {
+    padding: 0.45rem 0.65rem;
+  }
+
+  .menu-actions {
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 0 1rem;
+  }
+
+  .menu-user {
+    width: 100%;
+    align-items: center;
+    text-align: center;
+  }
+}

--- a/client/src/components/Menu/Menu.jsx
+++ b/client/src/components/Menu/Menu.jsx
@@ -1,35 +1,95 @@
-import { NavLink } from 'react-router';
-import './Menu.css';
-import DarkLight from '../DarkLight/DarkLight';
-import { useContext, useState } from 'react';
-import ThemeContext from '../../context/ThemeContext';
-import NewVehicle from '../NewVehicle/NewVehicle';
+import { NavLink, useNavigate } from "react-router";
+import "./Menu.css";
+import DarkLight from "../DarkLight/DarkLight";
+import { useContext, useState } from "react";
+import ThemeContext from "../../context/ThemeContext";
+import { useAuth } from "../../context/AuthContext";
+import { useToast } from "../../context/ToastContext";
+import NewVehicle from "../NewVehicle/NewVehicle";
 
 export default function Menu({ title, onAddVehicle }) {
-    const { isDarkMode } = useContext(ThemeContext);
-    const [showModal, setShowModal] = useState(false);
+  const { isDarkMode } = useContext(ThemeContext);
+  const { user, isAuthenticated, logout } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
 
-    return (
-        <>
-            <ul className={isDarkMode ? 'menu menu_dark' : 'menu menulight'}>
-                <li><NavLink to='/'>Home</NavLink></li>
-                <li><NavLink to='/expired'>Scaduti</NavLink></li>
-                <li><NavLink to='/expiring'>In Scadenza</NavLink></li>
-            </ul>
+  const handleLogout = () => {
+    logout();
 
-            <h1>{title}</h1>
+    showToast({
+      type: "success",
+      title: "Logout effettuato",
+      message: "Sei uscito dal tuo account.",
+    });
 
-            <div className="menu-actions">
-                <DarkLight />
-                <button onClick={() => setShowModal(true)}>Nuovo ➕</button>
-            </div>
+    navigate("/login", { replace: true });
+  };
 
-            {showModal && (
-                <NewVehicle
-                  onAdd={onAddVehicle}
-                  onClose={() => setShowModal(false)}
-                />
-            )}
-        </>
-    );
+  return (
+    <>
+      <ul className={isDarkMode ? "menu menu_dark" : "menu menulight"}>
+        <li>
+          <NavLink to="/">Home</NavLink>
+        </li>
+        <li>
+          <NavLink to="/expired">Scaduti</NavLink>
+        </li>
+        <li>
+          <NavLink to="/expiring">In Scadenza</NavLink>
+        </li>
+
+        {!isAuthenticated && (
+          <>
+            <li>
+              <NavLink to="/login">Login</NavLink>
+            </li>
+            <li>
+              <NavLink to="/register">Registrati</NavLink>
+            </li>
+          </>
+        )}
+      </ul>
+
+      <h1>{title}</h1>
+
+      <div className="menu-actions">
+        {isAuthenticated && (
+          <div className="menu-user">
+            <span className="menu-user-label">Utente</span>
+            <strong>{user?.name || user?.email}</strong>
+          </div>
+        )}
+
+        <DarkLight />
+
+        {isAuthenticated ? (
+          <>
+            <button type="button" onClick={() => setShowModal(true)}>
+              Nuovo ➕
+            </button>
+
+            <button
+              type="button"
+              className="menu-logout"
+              onClick={handleLogout}
+            >
+              Logout
+            </button>
+          </>
+        ) : (
+          <button type="button" onClick={() => navigate("/login")}>
+            Accedi
+          </button>
+        )}
+      </div>
+
+      {showModal && (
+        <NewVehicle
+          onAdd={onAddVehicle}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
## Riepilogo

Aggiunta della gestione base dell’autenticazione nel menu principale.

## Modifiche principali

- mostrati i link Login e Registrati quando l’utente non è autenticato
- mostrato l’utente loggato nel menu azioni
- aggiunto bottone Logout
- aggiunto toast di conferma dopo logout
- reindirizzamento alla pagina Login dopo logout
- nascosto il bottone Nuovo veicolo quando l’utente non è autenticato
- aggiunti stili responsive per utente e logout nel menu

## Verifiche

- [x] `git diff --check`
- [x] `npm --prefix client run build`