### PR TITLE
Fix dashboard vehicle name and dark state messages

### DIFF
--- a/client/src/components/DashboardSummary/DashboardSummary.jsx
+++ b/client/src/components/DashboardSummary/DashboardSummary.jsx
@@ -26,7 +26,7 @@ function formatDate(date) {
 }
 
 function getVehicleName(vehicle) {
-  return [vehicle.marca, vehicle.modello].filter(Boolean).join(" ") || "Veicolo";
+  return [vehicle.brand, vehicle.model].filter(Boolean).join(" ") || "Veicolo";
 }
 
 function getNextExpiry(vehicles = []) {

--- a/client/src/components/StateMessage/StateMessage.css
+++ b/client/src/components/StateMessage/StateMessage.css
@@ -51,3 +51,23 @@
   outline: 3px solid rgba(37, 99, 235, 0.35);
   outline-offset: 3px;
 }
+
+body.dark .state-message {
+  background-color: #2f2f42;
+  color: #f5f5f5;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+body.dark .state-message p {
+  color: #d7d7e5;
+  opacity: 1;
+}
+
+body.dark .state-message-error {
+  border-color: rgba(255, 138, 128, 0.4);
+}
+
+body.dark .state-message-action {
+  background: #60a5fa;
+  color: #111827;
+}


### PR DESCRIPTION
## Riepilogo
- Corretto il nome del veicolo nella card “Prossima scadenza”
- La dashboard ora usa i campi reali `brand` e `model`
- Migliorata la leggibilità dei messaggi di stato in tema scuro
- Aggiornati sfondo, testo, bordo errore e pulsante retry per dark mode

## Verifiche
- git diff --check
- npm --prefix client run build