### PR TITLE
Aggiunge avvisi interni per scadenze veicoli

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import DashboardSummary from "./components/DashboardSummary/DashboardSummary";
 import EmptyState from "./components/EmptyState/EmptyState";
 import StateMessage from "./components/StateMessage/StateMessage";
 import ThemeContext from "./context/ThemeContext";
+import ExpiryAlerts from "./components/ExpiryAlerts/ExpiryAlerts";
 
 function App({
   vehicles,
@@ -20,6 +21,9 @@ function App({
   return (
     <div className={isDarkMode ? "app dark" : "app light"}>
       {showDashboard && <DashboardSummary vehicles={vehicles} />}
+      {showDashboard && !isLoading && !error && vehicles.length > 0 && (
+        <ExpiryAlerts vehicles={vehicles} />
+      )}
 
       {isLoading ? (
         <StateMessage

--- a/client/src/components/ExpiryAlerts/ExpiryAlerts.css
+++ b/client/src/components/ExpiryAlerts/ExpiryAlerts.css
@@ -1,0 +1,150 @@
+.expiry-alerts {
+  width: min(100%, 960px);
+  margin: 0 auto 1.5rem;
+  padding: 1.2rem;
+  border-radius: 18px;
+  background-color: #ffffff;
+  color: #222;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
+.expiry-alerts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.expiry-alerts-kicker {
+  display: block;
+  margin-bottom: 0.2rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.65;
+}
+
+.expiry-alerts h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.expiry-alerts-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.6rem;
+  border-radius: 999px;
+  background-color: #fdecea;
+  color: #b71c1c;
+  font-weight: 800;
+}
+
+.expiry-alerts-empty {
+  margin: 0;
+  color: #2e7d32;
+  font-weight: 600;
+}
+
+.expiry-alerts-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.expiry-alert {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem;
+  border-radius: 14px;
+  background-color: #f7f8fb;
+}
+
+.expiry-alert strong {
+  display: block;
+  margin-bottom: 0.15rem;
+}
+
+.expiry-alert p {
+  margin: 0;
+  line-height: 1.45;
+  opacity: 0.8;
+}
+
+.expiry-alert-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0.35rem;
+  border-radius: 50%;
+  background-color: #f9a825;
+}
+
+.expiry-alert--expired .expiry-alert-dot {
+  background-color: #d32f2f;
+}
+
+.expiry-alert--expired {
+  border-left: 5px solid #d32f2f;
+}
+
+.expiry-alert--expiring {
+  border-left: 5px solid #f9a825;
+}
+
+body.dark .expiry-alerts {
+  background-color: #2f2f42;
+  color: #f5f5f5;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+body.dark .expiry-alert {
+  background-color: #252536;
+}
+
+body.dark .expiry-alert p {
+  opacity: 1;
+  color: #d7d7e5;
+}
+
+body.dark .expiry-alerts-empty {
+  color: #9be7c0;
+}
+
+body.dark .expiry-alerts-count {
+  background-color: rgba(211, 47, 47, 0.2);
+  color: #ff8a80;
+}
+
+@media (max-width: 768px) {
+  .expiry-alerts {
+    width: calc(100% - 1.5rem);
+    max-width: 560px;
+    padding: 1rem;
+  }
+
+  .expiry-alerts-header {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .expiry-alerts {
+    border-radius: 14px;
+  }
+
+  .expiry-alert {
+    padding: 0.8rem;
+  }
+
+  .expiry-alerts h2 {
+    font-size: 1.15rem;
+  }
+}

--- a/client/src/components/ExpiryAlerts/ExpiryAlerts.jsx
+++ b/client/src/components/ExpiryAlerts/ExpiryAlerts.jsx
@@ -1,0 +1,144 @@
+import { useMemo } from "react";
+import { parseDate } from "../../utils/vehicleDates";
+import "./ExpiryAlerts.css";
+
+const expiryFields = [
+    {
+        key: "scadenza_bollo",
+        label: "Bollo",
+        expiredFlag: "expired_car_tax",
+        expiringFlag: "expiring_car_tax",
+    },
+    {
+        key: "scadenza_assicurazione",
+        label: "Assicurazione",
+        expiredFlag: "expired_insurance",
+        expiringFlag: "expiring_insurance",
+    },
+    {
+        key: "scadenza_revisione",
+        label: "Revisione",
+        expiredFlag: "expired_revision",
+        expiringFlag: "expiring_revision",
+    },
+];
+
+function getVehicleName(vehicle) {
+    return [vehicle.brand, vehicle.model].filter(Boolean).join(" ") || "Veicolo";
+}
+
+function formatDate(date) {
+    return new Intl.DateTimeFormat("it-IT", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+    }).format(date);
+}
+
+function getDaysDifference(date) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const expiryDate = new Date(date);
+    expiryDate.setHours(0, 0, 0, 0);
+
+    return Math.ceil((expiryDate - today) / (1000 * 60 * 60 * 24));
+}
+
+function buildExpiryAlerts(vehicles = []) {
+    return vehicles
+        .flatMap((vehicle) =>
+            expiryFields
+                .map((field) => {
+                    const date = parseDate(vehicle[field.key]);
+
+                    if (!date) {
+                        return null;
+                    }
+
+                    const isExpired = Boolean(vehicle[field.expiredFlag]);
+                    const isExpiring = Boolean(vehicle[field.expiringFlag]);
+
+                    if (!isExpired && !isExpiring) {
+                        return null;
+                    }
+
+                    const daysDifference = getDaysDifference(date);
+
+                    return {
+                        id: `${vehicle.id || vehicle._id}-${field.key}`,
+                        vehicleName: getVehicleName(vehicle),
+                        type: field.label,
+                        date,
+                        daysDifference,
+                        status: isExpired ? "expired" : "expiring",
+                    };
+                })
+                .filter(Boolean)
+        )
+        .sort((alertA, alertB) => {
+            if (alertA.status !== alertB.status) {
+                return alertA.status === "expired" ? -1 : 1;
+            }
+
+            return alertA.date - alertB.date;
+        })
+        .slice(0, 5);
+}
+
+function getAlertMessage(alert) {
+    if (alert.status === "expired") {
+        return `${alert.type} scaduta il ${formatDate(alert.date)}`;
+    }
+
+    if (alert.daysDifference === 0) {
+        return `${alert.type} in scadenza oggi`;
+    }
+
+    if (alert.daysDifference === 1) {
+        return `${alert.type} in scadenza domani`;
+    }
+
+    return `${alert.type} in scadenza tra ${alert.daysDifference} giorni`;
+}
+
+export default function ExpiryAlerts({ vehicles }) {
+    const alerts = useMemo(() => buildExpiryAlerts(vehicles), [vehicles]);
+
+    return (
+        <section className="expiry-alerts" aria-label="Avvisi scadenze">
+            <div className="expiry-alerts-header">
+                <div>
+                    <span className="expiry-alerts-kicker">Notifiche</span>
+                    <h2>Avvisi scadenze</h2>
+                </div>
+
+                {alerts.length > 0 && (
+                    <span className="expiry-alerts-count">{alerts.length}</span>
+                )}
+            </div>
+
+            {alerts.length === 0 ? (
+                <p className="expiry-alerts-empty">
+                    Nessun veicolo scaduto o in scadenza. Tutto sotto controllo.
+                </p>
+            ) : (
+                <ul className="expiry-alerts-list">
+                    {alerts.map((alert) => (
+                        <li
+                            key={alert.id}
+                            className={`expiry-alert expiry-alert--${alert.status}`}
+                        >
+                            <span className="expiry-alert-dot" aria-hidden="true" />
+
+                            <div>
+                                <strong>{alert.vehicleName}</strong>
+                                <p>{getAlertMessage(alert)}</p>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}


### PR DESCRIPTION
## Riepilogo
- Aggiunto il nuovo componente `ExpiryAlerts`
- Mostra una card “Avvisi scadenze” nella Home
- Evidenzia veicoli scaduti e in scadenza
- Ordina gli avvisi dando priorità alle scadenze già scadute
- Mostra massimo 5 avvisi per mantenere la dashboard pulita
- Aggiunto messaggio positivo se non ci sono veicoli scaduti o in scadenza
- Aggiunti stili responsive e supporto tema scuro

## Verifiche
- git diff --check
- npm --prefix client run build