### PR TITLE
Aggiunge notifiche email settimanali per scadenze veicoli

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,12 @@
 PORT=5000
 MONGO_URI=mongodb+srv://username:password@cluster.mongodb.net/my-garage
 JWT_SECRET=your_jwt_secret
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=My Garage <noreply@mygarage.app>
+SMTP_SECURE=false
+SMTP_TIMEOUT_MS=10000
+
+INTERNAL_CRON_SECRET=

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
-        "mongoose": "^9.0.1"
+        "mongoose": "^9.0.1",
+        "nodemailer": "^9.0.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.11"
@@ -1029,6 +1030,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.0.1"
+    "mongoose": "^9.0.1",
+    "nodemailer": "^9.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -5,6 +5,8 @@ const healthRoutes = require("./routes/healthRoutes");
 const vehicleRoutes = require("./routes/vehicleRoutes");
 const authRoutes = require("./routes/authRoutes");
 
+const notificationRoutes = require("./routes/notificationRoutes");
+
 const app = express();
 
 const allowedOrigins = [
@@ -30,6 +32,7 @@ app.use(express.json({ limit: "10mb" }));
 app.use("/api/health", healthRoutes);
 app.use("/api/vehicles", vehicleRoutes);
 app.use("/api/auth", authRoutes);
+app.use("/api/notifications", notificationRoutes);
 
 app.use((req, res) => {
   res.status(404).json({

--- a/server/src/controllers/notificationController.js
+++ b/server/src/controllers/notificationController.js
@@ -1,0 +1,146 @@
+const User = require("../models/User");
+const Vehicle = require("../models/Vehicle");
+const NotificationLog = require("../models/NotificationLog");
+const { sendEmail } = require("../utils/email");
+const {
+  buildExpiryAlertsForVehicles,
+  getAlertText,
+} = require("../utils/expiryAlerts");
+
+const WEEKLY_EXPIRY_EMAIL_TYPE = "weekly-expiry-email";
+
+function getCurrentWeekKey(date = new Date()) {
+  const currentDate = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  );
+
+  const dayNumber = currentDate.getUTCDay() || 7;
+  currentDate.setUTCDate(currentDate.getUTCDate() + 4 - dayNumber);
+
+  const yearStart = new Date(Date.UTC(currentDate.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(((currentDate - yearStart) / 86400000 + 1) / 7);
+
+  return `${currentDate.getUTCFullYear()}-W${String(weekNumber).padStart(
+    2,
+    "0"
+  )}`;
+}
+
+function buildWeeklyEmailText({ user, alerts }) {
+  const alertLines = alerts.map((alert) => `- ${getAlertText(alert)}`);
+
+  return [
+    `Ciao ${user.name},`,
+    "",
+    "ecco il riepilogo settimanale delle scadenze da controllare su My Garage:",
+    "",
+    ...alertLines,
+    "",
+    "Accedi a My Garage per controllare e aggiornare le tue scadenze.",
+    "",
+    "A presto,",
+    "My Garage",
+  ].join("\n");
+}
+
+function checkCronSecret(req, res) {
+  const configuredSecret = process.env.INTERNAL_CRON_SECRET;
+  const requestSecret = req.get("x-cron-secret");
+
+  if (!configuredSecret) {
+    res.status(500).json({
+      message: "INTERNAL_CRON_SECRET non configurato.",
+    });
+    return false;
+  }
+
+  if (!requestSecret || requestSecret !== configuredSecret) {
+    res.status(401).json({
+      message: "Non autorizzato.",
+    });
+    return false;
+  }
+
+  return true;
+}
+
+async function sendWeeklyExpiryEmails(req, res) {
+  if (!checkCronSecret(req, res)) {
+    return;
+  }
+
+  try {
+    const periodKey = getCurrentWeekKey();
+    const users = await User.find().select("name email");
+
+    const summary = {
+      periodKey,
+      usersChecked: users.length,
+      emailsSent: 0,
+      skippedNoAlerts: 0,
+      skippedAlreadySent: 0,
+      failed: 0,
+      failures: [],
+    };
+
+    for (const user of users) {
+      const vehicles = await Vehicle.find({ user: user._id });
+      const alerts = buildExpiryAlertsForVehicles(vehicles);
+
+      if (alerts.length === 0) {
+        summary.skippedNoAlerts += 1;
+        continue;
+      }
+
+      const existingLog = await NotificationLog.findOne({
+        user: user._id,
+        type: WEEKLY_EXPIRY_EMAIL_TYPE,
+        periodKey,
+      });
+
+      if (existingLog) {
+        summary.skippedAlreadySent += 1;
+        continue;
+      }
+
+      try {
+        await sendEmail({
+          to: user.email,
+          subject: "My Garage - riepilogo scadenze veicoli",
+          text: buildWeeklyEmailText({ user, alerts }),
+        });
+
+        await NotificationLog.create({
+          user: user._id,
+          type: WEEKLY_EXPIRY_EMAIL_TYPE,
+          periodKey,
+          alertCount: alerts.length,
+        });
+
+        summary.emailsSent += 1;
+      } catch (error) {
+        summary.failed += 1;
+        summary.failures.push({
+          userId: user._id,
+          email: user.email,
+          message: error.message,
+        });
+      }
+    }
+
+    res.json({
+      message: "Controllo notifiche settimanali completato.",
+      summary,
+    });
+  } catch (error) {
+    console.error("Errore notifiche settimanali:", error);
+
+    res.status(500).json({
+      message: "Errore durante l'invio delle notifiche settimanali.",
+    });
+  }
+}
+
+module.exports = {
+  sendWeeklyExpiryEmails,
+};

--- a/server/src/models/NotificationLog.js
+++ b/server/src/models/NotificationLog.js
@@ -1,0 +1,45 @@
+const mongoose = require("mongoose");
+
+const notificationLogSchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      index: true,
+    },
+    type: {
+      type: String,
+      required: true,
+      enum: ["weekly-expiry-email"],
+    },
+    periodKey: {
+      type: String,
+      required: true,
+    },
+    sentAt: {
+      type: Date,
+      default: Date.now,
+    },
+    alertCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+notificationLogSchema.index(
+  {
+    user: 1,
+    type: 1,
+    periodKey: 1,
+  },
+  {
+    unique: true,
+  }
+);
+
+module.exports = mongoose.model("NotificationLog", notificationLogSchema);

--- a/server/src/routes/notificationRoutes.js
+++ b/server/src/routes/notificationRoutes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const {
+  sendWeeklyExpiryEmails,
+} = require("../controllers/notificationController");
+
+const router = express.Router();
+
+router.post("/weekly-expiry-email", sendWeeklyExpiryEmails);
+
+module.exports = router;

--- a/server/src/utils/email.js
+++ b/server/src/utils/email.js
@@ -1,0 +1,61 @@
+const nodemailer = require("nodemailer");
+
+function getSmtpConfig() {
+  const {
+    SMTP_HOST,
+    SMTP_PORT,
+    SMTP_USER,
+    SMTP_PASS,
+    SMTP_FROM,
+    SMTP_SECURE,
+    SMTP_TIMEOUT_MS,
+  } = process.env;
+
+  if (!SMTP_HOST || !SMTP_PORT || !SMTP_USER || !SMTP_PASS || !SMTP_FROM) {
+    throw new Error("Configurazione SMTP incompleta.");
+  }
+
+  return {
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT),
+    secure: SMTP_SECURE === "true",
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASS,
+    },
+    connectionTimeout: Number(SMTP_TIMEOUT_MS || 10000),
+    greetingTimeout: Number(SMTP_TIMEOUT_MS || 10000),
+    socketTimeout: Number(SMTP_TIMEOUT_MS || 10000),
+    from: SMTP_FROM,
+  };
+}
+
+function createTransporter() {
+  const smtpConfig = getSmtpConfig();
+
+  return nodemailer.createTransport({
+    host: smtpConfig.host,
+    port: smtpConfig.port,
+    secure: smtpConfig.secure,
+    auth: smtpConfig.auth,
+    connectionTimeout: smtpConfig.connectionTimeout,
+    greetingTimeout: smtpConfig.greetingTimeout,
+    socketTimeout: smtpConfig.socketTimeout,
+  });
+}
+
+async function sendEmail({ to, subject, text }) {
+  const smtpConfig = getSmtpConfig();
+  const transporter = createTransporter();
+
+  return transporter.sendMail({
+    from: smtpConfig.from,
+    to,
+    subject,
+    text,
+  });
+}
+
+module.exports = {
+  sendEmail,
+};

--- a/server/src/utils/expiryAlerts.js
+++ b/server/src/utils/expiryAlerts.js
@@ -1,0 +1,120 @@
+const DAYS_BEFORE_EXPIRY = 30;
+
+const expiryFields = [
+  {
+    key: "taxExpiry",
+    label: "Bollo",
+  },
+  {
+    key: "insuranceExpiry",
+    label: "Assicurazione",
+  },
+  {
+    key: "inspectionExpiry",
+    label: "Revisione",
+  },
+];
+
+function normalizeDate(dateValue) {
+  if (!dateValue) {
+    return null;
+  }
+
+  const date = new Date(dateValue);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function getToday() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function getDaysDifference(date) {
+  const today = getToday();
+  return Math.ceil((date - today) / (1000 * 60 * 60 * 24));
+}
+
+function getVehicleName(vehicle) {
+  return [vehicle.brand, vehicle.model].filter(Boolean).join(" ") || "Veicolo";
+}
+
+function buildExpiryAlertsForVehicle(vehicle) {
+  return expiryFields
+    .map((field) => {
+      const date = normalizeDate(vehicle[field.key]);
+
+      if (!date) {
+        return null;
+      }
+
+      const daysDifference = getDaysDifference(date);
+      const isExpired = daysDifference < 0;
+      const isExpiring =
+        daysDifference >= 0 && daysDifference <= DAYS_BEFORE_EXPIRY;
+
+      if (!isExpired && !isExpiring) {
+        return null;
+      }
+
+      return {
+        vehicleId: vehicle._id,
+        vehicleName: getVehicleName(vehicle),
+        plate: vehicle.plate,
+        type: field.label,
+        date,
+        daysDifference,
+        status: isExpired ? "expired" : "expiring",
+      };
+    })
+    .filter(Boolean);
+}
+
+function buildExpiryAlertsForVehicles(vehicles = []) {
+  return vehicles
+    .flatMap((vehicle) => buildExpiryAlertsForVehicle(vehicle))
+    .sort((alertA, alertB) => {
+      if (alertA.status !== alertB.status) {
+        return alertA.status === "expired" ? -1 : 1;
+      }
+
+      return alertA.date - alertB.date;
+    });
+}
+
+function formatDateIt(date) {
+  return new Intl.DateTimeFormat("it-IT", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
+function getAlertText(alert) {
+  if (alert.status === "expired") {
+    return `${alert.vehicleName} - ${alert.type} scaduta il ${formatDateIt(
+      alert.date
+    )}`;
+  }
+
+  if (alert.daysDifference === 0) {
+    return `${alert.vehicleName} - ${alert.type} in scadenza oggi`;
+  }
+
+  if (alert.daysDifference === 1) {
+    return `${alert.vehicleName} - ${alert.type} in scadenza domani`;
+  }
+
+  return `${alert.vehicleName} - ${alert.type} in scadenza tra ${alert.daysDifference} giorni`;
+}
+
+module.exports = {
+  buildExpiryAlertsForVehicles,
+  getAlertText,
+};


### PR DESCRIPTION
## Riepilogo
- Aggiunta logica backend per notifiche email settimanali
- Aggiunto endpoint interno protetto `POST /api/notifications/weekly-expiry-email`
- Protezione tramite header `x-cron-secret`
- Aggiunto calcolo scadenze veicoli scaduti/in scadenza
- Aggiunto invio email tramite Nodemailer/Brevo
- Aggiunto modello `NotificationLog` per evitare invii duplicati nella stessa settimana
- Aggiornato `.env.example` con variabili SMTP e `INTERNAL_CRON_SECRET`

## Test
- Endpoint senza `x-cron-secret` → 401 Non autorizzato
- Endpoint con `x-cron-secret` corretto → controllo notifiche completato
- Primo invio reale Brevo → `emailsSent: 1`, `failed: 0`
- Secondo invio nella stessa settimana → `skippedAlreadySent: 1`, `emailsSent: 0`
- `git diff --check`
- `npm --prefix server start`