### PR TITLE
Chiarisce il comportamento delle notifiche push per dispositivo

### DIFF
--- a/client/src/components/NotificationSettings/NotificationSettings.css
+++ b/client/src/components/NotificationSettings/NotificationSettings.css
@@ -128,3 +128,10 @@ body.dark .notification-settings__error {
     width: 100%;
   }
 }
+
+.notification-settings__hint {
+  margin: 0;
+  color: var(--text-muted, #666);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}

--- a/client/src/components/NotificationSettings/NotificationSettings.jsx
+++ b/client/src/components/NotificationSettings/NotificationSettings.jsx
@@ -35,7 +35,7 @@ function NotificationSettings() {
       } catch (err) {
         setError(
           err.message ||
-            "Non è stato possibile caricare le preferenze notifiche."
+          "Non è stato possibile caricare le preferenze notifiche."
         );
       } finally {
         setIsLoading(false);
@@ -57,7 +57,7 @@ function NotificationSettings() {
       } catch (err) {
         setPushError(
           err.message ||
-            "Non è stato possibile verificare lo stato delle notifiche push."
+          "Non è stato possibile verificare lo stato delle notifiche push."
         );
       }
     }
@@ -87,7 +87,7 @@ function NotificationSettings() {
       setEnabled(previousEnabled);
       setError(
         err.message ||
-          "Non è stato possibile aggiornare le preferenze notifiche."
+        "Non è stato possibile aggiornare le preferenze notifiche."
       );
     } finally {
       setIsSaving(false);
@@ -187,6 +187,15 @@ function NotificationSettings() {
           <p>
             Ricevi notifiche browser su PC o smartphone quando ci sono scadenze
             importanti da controllare.
+          </p>
+          <p className="notification-settings__hint">
+            Le notifiche push vanno attivate separatamente su ogni dispositivo e
+            browser. Se le hai attivate sul PC, non sono automaticamente attive anche
+            sullo smartphone.
+          </p>
+          <p className="notification-settings__hint">
+            Su Android puoi attivarle dal browser. Su iPhone potrebbe essere
+            necessario aggiungere My Garage alla schermata Home e aprirlo da lì.
           </p>
         </div>
 


### PR DESCRIPTION
## Descrizione

Questa PR migliora i testi della pagina `/impostazioni` per spiegare meglio il comportamento delle notifiche push browser.

Le notifiche push sono legate al singolo dispositivo e al singolo browser: se vengono attivate sul PC, non risultano automaticamente attive anche sullo smartphone.

## Modifiche principali

- Aggiornato il testo della sezione “Notifiche su questo dispositivo”
- Aggiunta nota che le notifiche push vanno attivate separatamente su ogni dispositivo/browser
- Aggiunta nota per smartphone:
  - su Android possono essere attivate dal browser
  - su iPhone potrebbe essere necessario aggiungere My Garage alla schermata Home
- Aggiunto stile dedicato per i testi informativi

## Test effettuati

- Verificata modifica nella pagina `/impostazioni`
- Commit creato correttamente
- Working tree pulito