### PR TITLE
Aggiorna i link ufficiali della ricerca da targa

### DIFF
--- a/server/src/controllers/plateLookupController.js
+++ b/server/src/controllers/plateLookupController.js
@@ -35,15 +35,15 @@ label: "Assicurazione",
 message:
 "Verifica se il veicolo risulta assicurato tramite il servizio ufficiale del Portale dell'Automobilista.",
 officialUrl:
-"https://www.ilportaledellautomobilista.it/web/portale-automobilista/ext/verifica-copertura-rc?_CoperturaRC_WAR_ServiziAlCittadinowar100SNAPSHOTesercizio_action=sceltaTipologia&p_p_col_count=1&p_p_col_id=_118_INSTANCE_hoIzOCy6I6vu__column-2&p_p_id=CoperturaRC_WAR_ServiziAlCittadinowar100SNAPSHOTesercizio&p_p_lifecycle=0&p_p_mode=view&p_p_state=normal",
+"https://www.ilportaledellautomobilista.it/web/portale-automobilista/cittadino-verifica-copertura-rc",
 },
 inspection: {
 status: "unknown",
 label: "Revisione",
 message:
-"Verifica l'ultima revisione tramite il servizio ufficiale del Portale dell'Automobilista. La prossima scadenza può essere poi inserita manualmente in My Garage.",
+"Verifica l'ultima revisione tramite la pagina ufficiale del Portale dell'Automobilista. Se il servizio diretto dà problemi con il captcha, apri la pagina e usa il pulsante di verifica disponibile sul sito.",
 officialUrl:
-"https://www.ilportaledellautomobilista.it/interrogazionistoricorevisioni/spa/",
+"https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-revisioni-effettuate-ms",
 },
 tax: {
 status: "manual_required",


### PR DESCRIPTION
## Cosa cambia

Aggiorna i link ufficiali mostrati nella ricerca assistita da targa.

## Dettagli

- Sostituito il link lungo/diretto per la verifica RCA con la pagina ufficiale più stabile del Portale dell’Automobilista
- Sostituito il link diretto alla SPA revisioni con la pagina ufficiale “Verifica revisioni effettuate”
- Lasciato invariato il link ACI per il bollo, che risulta funzionante

## Test effettuati

- `git diff --check`
- `npm --prefix client run build`