### PR TITLE
Abilita CORS per il frontend demo

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -13,7 +13,8 @@ const app = express();
 const allowedOrigins = [
   "https://my-garage-expiration.netlify.app",
   "http://localhost:5173",
-];
+  process.env.CLIENT_URL,
+].filter(Boolean);
 
 app.use(
   cors({


### PR DESCRIPTION
## Descrizione

Questa PR aggiorna la configurazione CORS del backend per permettere le richieste provenienti dal frontend demo di My Garage.

Il backend ora include anche `process.env.CLIENT_URL` tra gli origin autorizzati, così l’ambiente demo su Netlify può comunicare correttamente con l’API demo su Render.

## Modifiche

- Aggiunto `process.env.CLIENT_URL` alla lista degli origin consentiti
- Aggiunto `.filter(Boolean)` per evitare valori vuoti nella whitelist CORS
- Preparato il backend demo a usare l’URL configurato nelle environment variables di Render

## Contesto

La demo Netlify (`https://my-garage-demo.netlify.app`) riceveva un errore CORS durante la registrazione perché il suo origin non era presente nella whitelist del backend.

## Test

- Verificato diff della modifica
- Da testare dopo il merge e redeploy Render:
  - registrazione da frontend demo
  - login da frontend demo
  - chiamate API verso backend demo