### PR TITLE
Aggiunge limiti backend per la modalità demo

### DIFF
--- a/server/src/controllers/authController.js
+++ b/server/src/controllers/authController.js
@@ -20,6 +20,16 @@ function sanitizeUser(user) {
 
 async function registerUser(req, res) {
   try {
+    if (
+      process.env.DEMO_MODE === "true" &&
+      process.env.DEMO_REGISTRATION_ENABLED !== "true"
+    ) {
+      return res.status(403).json({
+        message:
+          "La registrazione è disabilitata nell'ambiente demo. Usa l'account demo fornito.",
+      });
+    }
+
     const { name, email, password } = req.body;
 
     if (!name || !email || !password) {

--- a/server/src/controllers/vehicleController.js
+++ b/server/src/controllers/vehicleController.js
@@ -32,6 +32,19 @@ async function getVehicleById(req, res) {
 }
 
 async function createVehicle(req, res) {
+  if (process.env.DEMO_MODE === "true") {
+    const demoMaxVehicles = Number(process.env.DEMO_MAX_VEHICLES || 5);
+    const vehicleCount = await Vehicle.countDocuments({
+      user: req.user._id,
+    });
+
+    if (vehicleCount >= demoMaxVehicles) {
+      return res.status(403).json({
+        status: "fail",
+        message: `Limite demo raggiunto: puoi creare al massimo ${demoMaxVehicles} veicoli.`,
+      });
+    }
+  }
   const vehicle = await Vehicle.create({
     ...req.body,
     user: req.user._id,


### PR DESCRIPTION
## Descrizione

Questa PR introduce alcune limitazioni backend dedicate all’ambiente demo di My Garage.

Le modifiche vengono applicate solo quando `DEMO_MODE=true`, così l’ambiente principale non viene modificato.

## Modifiche

- Blocca la registrazione pubblica quando:
  - `DEMO_MODE=true`
  - `DEMO_REGISTRATION_ENABLED` è diverso da `true`
- Aggiunge un limite massimo di veicoli creabili in modalità demo
- Il limite viene letto da `DEMO_MAX_VEHICLES`
- Se `DEMO_MAX_VEHICLES` non è configurato, il valore predefinito è 5 veicoli

## Variabili ambiente previste

```env
DEMO_MODE=true
DEMO_REGISTRATION_ENABLED=false
DEMO_MAX_VEHICLES=5