### PR TITLE
Nasconde i link navbar per utenti non autenticati

### DIFF
--- a/client/src/components/Menu/Menu.jsx
+++ b/client/src/components/Menu/Menu.jsx
@@ -28,34 +28,22 @@ export default function Menu({ title, onAddVehicle }) {
 
   return (
     <>
-      <ul className={isDarkMode ? "menu menu_dark" : "menu menulight"}>
-        <li>
-          <NavLink to="/">Home</NavLink>
-        </li>
-        <li>
-          <NavLink to="/expired">Scaduti</NavLink>
-        </li>
-        <li>
-          <NavLink to="/expiring">In Scadenza</NavLink>
-        </li>
-
-        {isAuthenticated && (
+      {isAuthenticated && (
+        <ul className={isDarkMode ? "menu menu_dark" : "menu menulight"}>
+          <li>
+            <NavLink to="/">Home</NavLink>
+          </li>
+          <li>
+            <NavLink to="/expired">Scaduti</NavLink>
+          </li>
+          <li>
+            <NavLink to="/expiring">In Scadenza</NavLink>
+          </li>
           <li>
             <NavLink to="/impostazioni">Impostazioni</NavLink>
           </li>
-        )}
-
-        {!isAuthenticated && (
-          <>
-            <li>
-              <NavLink to="/login">Login</NavLink>
-            </li>
-            <li>
-              <NavLink to="/register">Registrati</NavLink>
-            </li>
-          </>
-        )}
-      </ul>
+        </ul>
+      )}
 
       <h1>{title}</h1>
 


### PR DESCRIPTION
## Descrizione

Questa PR semplifica la navbar quando l’utente non è autenticato.

Nella demo, l’accesso parte dalla pagina login e la visualizzazione dei link `Home`, `Scaduti`, `In Scadenza` e `Registrati` prima del login risultava poco utile e potenzialmente distraente.

## Modifiche

- La navbar principale viene mostrata solo agli utenti autenticati
- Rimangono visibili dopo il login:
  - Home
  - Scaduti
  - In Scadenza
  - Impostazioni
- Da utente non autenticato non vengono più mostrati:
  - Home
  - Scaduti
  - In Scadenza
  - Registrati
- Rimane disponibile il pulsante `Accedi`

## Test

Eseguito con successo:

```bash
npm --prefix client run build