### PR TITLE
Migliora UI login demo e gestione errori limite

### DIFF
--- a/client/src/components/Menu/Menu.jsx
+++ b/client/src/components/Menu/Menu.jsx
@@ -57,7 +57,7 @@ export default function Menu({ title, onAddVehicle }) {
 
         <DarkLight />
 
-        {isAuthenticated ? (
+        {isAuthenticated && (
           <>
             <button type="button" onClick={() => setShowModal(true)}>
               Nuovo ➕
@@ -71,10 +71,6 @@ export default function Menu({ title, onAddVehicle }) {
               Logout
             </button>
           </>
-        ) : (
-          <button type="button" onClick={() => navigate("/login")}>
-            Accedi
-          </button>
         )}
       </div>
 

--- a/client/src/components/NewVehicle/NewVehicle.jsx
+++ b/client/src/components/NewVehicle/NewVehicle.jsx
@@ -235,9 +235,10 @@ export default function NewVehicle({ onAdd, onClose }) {
       });
 
       onClose();
-    } catch {
+    } catch (error) {
       setSubmitError(
-        "Non è stato possibile aggiungere il veicolo. Controlla la connessione e riprova."
+        error.message ||
+          "Non è stato possibile aggiungere il veicolo. Controlla la connessione e riprova."
       );
     } finally {
       setIsSubmitting(false);

--- a/client/src/routes/AppRoutes.jsx
+++ b/client/src/routes/AppRoutes.jsx
@@ -35,7 +35,7 @@ function isSameVehicle(vehicleA, vehicleB) {
 }
 
 function isAuthError(error) {
-  return error?.status === 401 || error?.status === 403;
+  return error?.status === 401;
 }
 
 function getStoredAuthToken() {


### PR DESCRIPTION
## Descrizione

Questa PR corregge alcuni comportamenti della demo legati alla pagina login e alla gestione del limite veicoli.

## Modifiche

- Rimosso il pulsante `Accedi` dalla barra superiore quando l’utente non è autenticato
- Mantenuto il toggle tema anche da guest
- Il codice ora considera come sessione scaduta solo gli errori `401`
- Gli errori `403` vengono gestiti come errori applicativi normali
- Il limite demo sui veicoli non forza più il logout
- Il form nuovo veicolo mostra il messaggio reale restituito dal backend, ad esempio:
  - `Limite demo raggiunto: puoi creare al massimo 2 veicoli.`

## Test

Eseguito con successo:

```bash
npm --prefix client run build