### PR TITLE
Corregge link assicurazione assistente targa

### DIFF
--- a/server/src/controllers/plateLookupController.js
+++ b/server/src/controllers/plateLookupController.js
@@ -35,7 +35,7 @@ const lookupVehicleByPlate = async (req, res) => {
             message:
                 "Verifica se il veicolo risulta assicurato tramite il servizio ufficiale del Portale dell'Automobilista.",
             officialUrl:
-                "https://www.ilportaledellautomobilista.it/web/portale-automobilista/ext/verifica-copertura-rc?_CoperturaRC_WAR_ServiziAlCittadinowar100SNAPSHOTesercizio_action=sceltaTipologia&p_p_col_count=1&p_p_col_id=_118_INSTANCE_hoIzOCy6I6vu__column-2&p_p_id=CoperturaRC_WAR_ServiziAlCittadinowar100SNAPSHOTesercizio&p_p_lifecycle=0&p_p_mode=view&p_p_state=normal",
+                "https://www.ilportaledellautomobilista.it/web/portale-automobilista/cittadino-verifica-copertura-rc",
         },
         inspection: {
             status: "unknown",


### PR DESCRIPTION
## Descrizione

Questa PR corregge il link dell’assistente targa per la verifica assicurazione.

## Modifiche

- Sostituito il link diretto alla verifica copertura RC che richiedeva il numero CIC
- Ripristinato il link alla pagina cittadino del Portale dell’Automobilista
- Nessuna modifica al link revisione, che nei test risulta funzionante
- Nessuna modifica al flusso frontend

## Test

Eseguito con successo:

```bash
npm --prefix client run build