### PR TITLE
Migliora navigazione riepilogo dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,11 +1,11 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
+import { useLocation } from "react-router";
 import "./App.css";
 import Vehicle from "./components/Vehicle/Vehicle";
 import DashboardSummary from "./components/DashboardSummary/DashboardSummary";
 import EmptyState from "./components/EmptyState/EmptyState";
 import StateMessage from "./components/StateMessage/StateMessage";
 import ThemeContext from "./context/ThemeContext";
-import ExpiryAlerts from "./components/ExpiryAlerts/ExpiryAlerts";
 
 function App({
   vehicles,
@@ -17,38 +17,50 @@ function App({
   emptyDescription = "Aggiungi un veicolo o controlla un'altra sezione.",
 }) {
   const { isDarkMode } = useContext(ThemeContext);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!location.state?.scrollToVehicles || isLoading) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      document
+        .getElementById("vehicles-list")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }, [location.key, location.state, isLoading, error, vehicles.length]);
 
   return (
     <div className={isDarkMode ? "app dark" : "app light"}>
       {showDashboard && <DashboardSummary vehicles={vehicles} />}
-      {showDashboard && !isLoading && !error && vehicles.length > 0 && (
-        <ExpiryAlerts vehicles={vehicles} />
-      )}
 
-      {isLoading ? (
-        <StateMessage
-          icon="⏳"
-          title="Caricamento veicoli..."
-          description="Sto recuperando le informazioni del tuo garage. Se il backend gratuito su Render si sta avviando, potrebbe servire qualche secondo."
-        />
-      ) : error ? (
-        <StateMessage
-          icon="⚠️"
-          title="Qualcosa è andato storto"
-          description={error}
-          type="error"
-          actionLabel="Riprova"
-          onAction={onRetry}
-        />
-      ) : vehicles.length === 0 ? (
-        <EmptyState
-          icon="🚗"
-          title={emptyTitle}
-          description={emptyDescription}
-        />
-      ) : (
-        vehicles.map((v) => <Vehicle key={v.id} vehicle={v} />)
-      )}
+      <section id="vehicles-list" className="vehicles-list-section">
+        {isLoading ? (
+          <StateMessage
+            icon="⏳"
+            title="Caricamento veicoli..."
+            description="Sto recuperando le informazioni del tuo garage. Se il backend gratuito su Render si sta avviando, potrebbe servire qualche secondo."
+          />
+        ) : error ? (
+          <StateMessage
+            icon="⚠️"
+            title="Qualcosa è andato storto"
+            description={error}
+            type="error"
+            actionLabel="Riprova"
+            onAction={onRetry}
+          />
+        ) : vehicles.length === 0 ? (
+          <EmptyState
+            icon="🚗"
+            title={emptyTitle}
+            description={emptyDescription}
+          />
+        ) : (
+          vehicles.map((v) => <Vehicle key={v.id} vehicle={v} />)
+        )}
+      </section>
     </div>
   );
 }

--- a/client/src/components/DashboardSummary/DashboardSummary.css
+++ b/client/src/components/DashboardSummary/DashboardSummary.css
@@ -209,3 +209,24 @@ body.dark .dashboard-next-expiry-badge--expired {
     border-top: 5px solid #1976d2;
   }
 }
+
+.dashboard-summary-card,
+.dashboard-next-expiry {
+  border: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dashboard-summary-card {
+  border-left: 6px solid #4db6ac;
+}
+
+.dashboard-next-expiry {
+  width: 100%;
+  border-left: 6px solid #1976d2;
+}
+
+.dashboard-summary-card--ok {
+  cursor: default;
+}

--- a/client/src/components/DashboardSummary/DashboardSummary.jsx
+++ b/client/src/components/DashboardSummary/DashboardSummary.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useNavigate } from "react-router";
 import { parseDate } from "../../utils/vehicleDates";
 import "./DashboardSummary.css";
 
@@ -62,6 +63,12 @@ function getNextExpiry(vehicles = []) {
 }
 
 export default function DashboardSummary({ vehicles }) {
+  const navigate = useNavigate();
+
+  const goToVehicleList = (path) => {
+    navigate(path, { state: { scrollToVehicles: true } });
+  };
+
   const dashboardSummary = useMemo(() => {
     const safeVehicles = vehicles ?? [];
     const total = safeVehicles.length;
@@ -104,20 +111,32 @@ export default function DashboardSummary({ vehicles }) {
   return (
     <section className="dashboard-summary" aria-label="Riepilogo veicoli">
       <div className="dashboard-summary-grid">
-        <div className="dashboard-summary-card">
+        <button
+          type="button"
+          className="dashboard-summary-card"
+          onClick={() => goToVehicleList("/")}
+        >
           <span className="dashboard-summary-label">Veicoli totali</span>
           <strong>{dashboardSummary.total}</strong>
-        </div>
+        </button>
 
-        <div className="dashboard-summary-card dashboard-summary-card--expired">
+        <button
+          type="button"
+          className="dashboard-summary-card dashboard-summary-card--expired"
+          onClick={() => goToVehicleList("/expired")}
+        >
           <span className="dashboard-summary-label">Scaduti</span>
           <strong>{dashboardSummary.expired}</strong>
-        </div>
+        </button>
 
-        <div className="dashboard-summary-card dashboard-summary-card--expiring">
+        <button
+          type="button"
+          className="dashboard-summary-card dashboard-summary-card--expiring"
+          onClick={() => goToVehicleList("/expiring")}
+        >
           <span className="dashboard-summary-label">In scadenza</span>
           <strong>{dashboardSummary.expiring}</strong>
-        </div>
+        </button>
 
         <div className="dashboard-summary-card dashboard-summary-card--ok">
           <span className="dashboard-summary-label">Tutto ok</span>
@@ -125,7 +144,11 @@ export default function DashboardSummary({ vehicles }) {
         </div>
       </div>
 
-      <article className="dashboard-next-expiry">
+      <button
+        type="button"
+        className="dashboard-next-expiry"
+        onClick={() => goToVehicleList("/")}
+      >
         <div>
           <span className="dashboard-summary-label">Prossima scadenza</span>
 
@@ -156,10 +179,12 @@ export default function DashboardSummary({ vehicles }) {
                 : "dashboard-next-expiry-badge"
             }
           >
-            {dashboardSummary.nextExpiry.isExpired ? "Scaduta" : "Da controllare"}
+            {dashboardSummary.nextExpiry.isExpired
+              ? "Scaduta"
+              : "Da controllare"}
           </span>
         )}
-      </article>
+      </button>
     </section>
   );
 }


### PR DESCRIPTION
## Riepilogo

- Rese cliccabili le card del riepilogo in Home
- Aggiunto lo scroll automatico verso l’elenco veicoli dopo il click sulle card
- Collegamenti aggiunti:
  - Veicoli totali → elenco completo dei veicoli
  - Scaduti → elenco veicoli scaduti
  - In scadenza → elenco veicoli in scadenza
  - Prossima scadenza → elenco veicoli
- Rimossa dalla Home la sezione duplicata “Avvisi scadenze”

## Controlli eseguiti

- [x] npm --prefix client run build
- [x] git diff --check

## Test manuali da fare

- [ ] Click su “Veicoli totali” → scroll all’elenco completo dei veicoli
- [ ] Click su “Scaduti” → apertura di `/expired` e scroll all’elenco filtrato
- [ ] Click su “In scadenza” → apertura di `/expiring` e scroll all’elenco filtrato
- [ ] Click su “Prossima scadenza” → scroll all’elenco veicoli
- [ ] Verificare che “Avvisi scadenze” non sia più visibile in Home
- [ ] Verificare layout mobile
- [ ] Verificare modalità dark/light