### PR TITLE
Rimuove prossima scadenza dal riepilogo dashboard

### DIFF
--- a/client/src/components/DashboardSummary/DashboardSummary.css
+++ b/client/src/components/DashboardSummary/DashboardSummary.css
@@ -10,25 +10,24 @@
   gap: 1rem;
 }
 
-.dashboard-summary-card,
-.dashboard-next-expiry {
-  background-color: #ffffff;
-  color: #222;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
-}
-
 .dashboard-summary-card {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   padding: 1rem;
-  border-radius: 16px;
+  border: 0;
   border-left: 6px solid #4db6ac;
+  border-radius: 16px;
+  background-color: #ffffff;
+  color: #222;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.dashboard-summary-card:hover,
-.dashboard-next-expiry:hover {
+.dashboard-summary-card:hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 22px rgba(0, 0, 0, 0.16);
 }
@@ -54,66 +53,25 @@
 
 .dashboard-summary-card--ok {
   border-left-color: #2e7d32;
+  cursor: default;
 }
 
-.dashboard-next-expiry {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 1rem;
-  padding: 1.2rem;
-  border-radius: 18px;
-  border-left: 6px solid #1976d2;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.dashboard-summary-card--ok:hover {
+  transform: none;
 }
 
-.dashboard-next-expiry h2 {
-  margin: 0.35rem 0 0.25rem;
-  font-size: 1.35rem;
-}
-
-.dashboard-next-expiry p {
-  margin: 0;
-  font-weight: 500;
-  opacity: 0.8;
-}
-
-.dashboard-next-expiry-badge {
-  flex-shrink: 0;
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  background-color: #fff3cd;
-  color: #7a5600;
-  font-size: 0.85rem;
-  font-weight: 700;
-}
-
-.dashboard-next-expiry-badge--expired {
-  background-color: #fdecea;
-  color: #b71c1c;
-}
-
-body.dark .dashboard-summary-card,
-body.dark .dashboard-next-expiry {
+body.dark .dashboard-summary-card {
   background-color: #2f2f42;
   color: #f5f5f5;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
 
-body.dark .dashboard-summary-card:hover,
-body.dark .dashboard-next-expiry:hover {
+body.dark .dashboard-summary-card:hover {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
 }
 
-body.dark .dashboard-next-expiry-badge {
-  background-color: rgba(249, 168, 37, 0.2);
-  color: #ffd166;
-}
-
-body.dark .dashboard-next-expiry-badge--expired {
-  background-color: rgba(211, 47, 47, 0.2);
-  color: #ff8a80;
+body.dark .dashboard-summary-card--ok:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
 
 @media (max-width: 768px) {
@@ -125,11 +83,6 @@ body.dark .dashboard-next-expiry-badge--expired {
 
   .dashboard-summary-grid {
     grid-template-columns: repeat(2, minmax(140px, 1fr));
-  }
-
-  .dashboard-next-expiry {
-    align-items: flex-start;
-    flex-direction: column;
   }
 }
 
@@ -150,8 +103,7 @@ body.dark .dashboard-next-expiry-badge--expired {
     border-left-width: 5px;
   }
 
-  .dashboard-summary-card:hover,
-  .dashboard-next-expiry:hover {
+  .dashboard-summary-card:hover {
     transform: none;
   }
 
@@ -162,20 +114,6 @@ body.dark .dashboard-next-expiry-badge--expired {
   .dashboard-summary-label {
     font-size: 0.82rem;
     line-height: 1.25;
-  }
-
-  .dashboard-next-expiry {
-    padding: 1rem;
-    border-radius: 14px;
-    border-left-width: 5px;
-  }
-
-  .dashboard-next-expiry h2 {
-    font-size: 1.15rem;
-  }
-
-  .dashboard-next-expiry p {
-    font-size: 0.95rem;
   }
 }
 
@@ -203,30 +141,4 @@ body.dark .dashboard-next-expiry-badge--expired {
   .dashboard-summary-card--ok {
     border-top-color: #2e7d32;
   }
-
-  .dashboard-next-expiry {
-    border-left: none;
-    border-top: 5px solid #1976d2;
-  }
-}
-
-.dashboard-summary-card,
-.dashboard-next-expiry {
-  border: 0;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.dashboard-summary-card {
-  border-left: 6px solid #4db6ac;
-}
-
-.dashboard-next-expiry {
-  width: 100%;
-  border-left: 6px solid #1976d2;
-}
-
-.dashboard-summary-card--ok {
-  cursor: default;
 }

--- a/client/src/components/DashboardSummary/DashboardSummary.jsx
+++ b/client/src/components/DashboardSummary/DashboardSummary.jsx
@@ -1,66 +1,6 @@
 import { useMemo } from "react";
 import { useNavigate } from "react-router";
-import { parseDate } from "../../utils/vehicleDates";
 import "./DashboardSummary.css";
-
-const expiryFields = [
-  {
-    key: "scadenza_bollo",
-    label: "Bollo",
-  },
-  {
-    key: "scadenza_assicurazione",
-    label: "Assicurazione",
-  },
-  {
-    key: "scadenza_revisione",
-    label: "Revisione",
-  },
-];
-
-function formatDate(date) {
-  return new Intl.DateTimeFormat("it-IT", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  }).format(date);
-}
-
-function getVehicleName(vehicle) {
-  return [vehicle.brand, vehicle.model].filter(Boolean).join(" ") || "Veicolo";
-}
-
-function getNextExpiry(vehicles = []) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const expiries = vehicles.flatMap((vehicle) =>
-    expiryFields
-      .map((field) => {
-        const date = parseDate(vehicle[field.key]);
-
-        if (!date) {
-          return null;
-        }
-
-        date.setHours(0, 0, 0, 0);
-
-        return {
-          vehicle,
-          type: field.label,
-          date,
-          isExpired: date < today,
-        };
-      })
-      .filter(Boolean)
-  );
-
-  if (expiries.length === 0) {
-    return null;
-  }
-
-  return expiries.sort((expiryA, expiryB) => expiryA.date - expiryB.date)[0];
-}
 
 export default function DashboardSummary({ vehicles }) {
   const navigate = useNavigate();
@@ -97,14 +37,11 @@ export default function DashboardSummary({ vehicles }) {
         !vehicle.expiring_revision
     ).length;
 
-    const nextExpiry = getNextExpiry(safeVehicles);
-
     return {
       total,
       expired,
       expiring,
       ok,
-      nextExpiry,
     };
   }, [vehicles]);
 
@@ -143,48 +80,6 @@ export default function DashboardSummary({ vehicles }) {
           <strong>{dashboardSummary.ok}</strong>
         </div>
       </div>
-
-      <button
-        type="button"
-        className="dashboard-next-expiry"
-        onClick={() => goToVehicleList("/")}
-      >
-        <div>
-          <span className="dashboard-summary-label">Prossima scadenza</span>
-
-          {dashboardSummary.nextExpiry ? (
-            <>
-              <h2>{getVehicleName(dashboardSummary.nextExpiry.vehicle)}</h2>
-              <p>
-                {dashboardSummary.nextExpiry.type} ·{" "}
-                {formatDate(dashboardSummary.nextExpiry.date)}
-              </p>
-            </>
-          ) : (
-            <>
-              <h2>Nessuna scadenza da mostrare</h2>
-              <p>
-                Aggiungi un veicolo per iniziare a monitorare bollo,
-                assicurazione e revisione.
-              </p>
-            </>
-          )}
-        </div>
-
-        {dashboardSummary.nextExpiry && (
-          <span
-            className={
-              dashboardSummary.nextExpiry.isExpired
-                ? "dashboard-next-expiry-badge dashboard-next-expiry-badge--expired"
-                : "dashboard-next-expiry-badge"
-            }
-          >
-            {dashboardSummary.nextExpiry.isExpired
-              ? "Scaduta"
-              : "Da controllare"}
-          </span>
-        )}
-      </button>
     </section>
   );
 }


### PR DESCRIPTION
## Riepilogo

- Rimossa la sezione “Prossima scadenza” dal riepilogo della Home
- Semplificato il componente `DashboardSummary`
- Ripuliti gli stili CSS non più utilizzati legati a `dashboard-next-expiry`
- Mantenute cliccabili le card:
  - Veicoli totali
  - Scaduti
  - In scadenza

## Controlli eseguiti

- [x] npm --prefix client run build
- [x] git diff --check

## Test manuali da fare

- [ ] Verificare che “Prossima scadenza” non sia più visibile in Home
- [ ] Click su “Veicoli totali” → scroll all’elenco completo dei veicoli
- [ ] Click su “Scaduti” → apertura di `/expired` e scroll all’elenco filtrato
- [ ] Click su “In scadenza” → apertura di `/expiring` e scroll all’elenco filtrato
- [ ] Verificare layout mobile
- [ ] Verificare modalità dark/light