### PR TITLE
Rende più vivaci i colori della demo

### DIFF
--- a/client/src/components/DashboardSummary/DashboardSummary.css
+++ b/client/src/components/DashboardSummary/DashboardSummary.css
@@ -21,14 +21,14 @@
   overflow: hidden;
   padding: 1.1rem;
   border: 1px solid rgba(15, 23, 42, 0.08);
-  border-left: 6px solid #4db6ac;
+  border-left: 6px solid #00acc1;
   border-radius: 22px;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(248, 253, 252, 0.94)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(236, 254, 255, 0.94)),
     #ffffff;
-  color: #1f2937;
+  color: #15313b;
   box-shadow:
-    0 14px 32px rgba(15, 23, 42, 0.1),
+    0 14px 32px rgba(0, 105, 92, 0.12),
     inset 0 1px 0 rgba(255, 255, 255, 0.8);
   font: inherit;
   text-align: left;
@@ -90,28 +90,28 @@
 }
 
 .dashboard-summary-card--expired {
-  border-left-color: #d32f2f;
+  border-left-color: #ef4444;
 }
 
 .dashboard-summary-card--expired::before {
-  background: rgba(211, 47, 47, 0.12);
+  background: rgba(239, 68, 68, 0.16);
 }
 
 .dashboard-summary-card--expiring {
-  border-left-color: #f9a825;
+  border-left-color: #f97316;
 }
 
 .dashboard-summary-card--expiring::before {
-  background: rgba(249, 168, 37, 0.16);
+  background: rgba(249, 115, 22, 0.18);
 }
 
 .dashboard-summary-card--ok {
-  border-left-color: #2e7d32;
+  border-left-color: #22c55e;
   cursor: default;
 }
 
 .dashboard-summary-card--ok::before {
-  background: rgba(46, 125, 50, 0.12);
+  background: rgba(34, 197, 94, 0.14);
 }
 
 .dashboard-summary-card--ok:hover {
@@ -257,6 +257,7 @@ body.dark .dashboard-summary-card--ok:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
+
   .dashboard-summary,
   .dashboard-summary-card,
   .dashboard-summary-card::before {

--- a/client/src/components/Menu/Menu.css
+++ b/client/src/components/Menu/Menu.css
@@ -28,31 +28,34 @@ body.dark .menu {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
-  min-height: 38px;
+  min-height: 42px;
   padding: 0.35rem 0;
-  color: #00695c;
-  font-size: 1.4rem;
+  color: #ff6f00;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
   font-weight: 950;
-  letter-spacing: -0.05em;
+  letter-spacing: -0.06em;
+  line-height: 1;
   text-decoration: none;
+  text-shadow: 0 2px 10px rgba(255, 111, 0, 0.22);
 }
 
 .menu-brand.active {
   background: transparent;
-  color: #00695c;
+  color: #ff6f00;
 }
 
 .menu-brand:hover {
-  color: #009688;
+  color: #f97316;
 }
 
 body.dark .menu-brand,
 body.dark .menu-brand.active {
-  color: #ccfbf1;
+  color: #fbbf24;
+  text-shadow: 0 2px 12px rgba(251, 191, 36, 0.25);
 }
 
 body.dark .menu-brand:hover {
-  color: #80cbc4;
+  color: #f97316;
 }
 
 .menu-links {
@@ -186,7 +189,7 @@ body.dark .menu-user {
 
   .menu-brand {
     justify-content: center;
-    font-size: 1.25rem;
+    font-size: 1.75rem;
   }
 
   .menu-links {


### PR DESCRIPTION
## Riepilogo

- Reso più evidente il brand “My Garage” nella navbar
- Aumentati dimensione, colore e contrasto del titolo nella navbar
- Migliorati i colori attivi e hover del menu
- Rese più vivaci le card riepilogo della dashboard
- Migliorati i colori di stato per scaduti, in scadenza e ok
- Nessuna modifica alla logica applicativa

## Controlli eseguiti

- [x] npm --prefix client run build
- [x] git diff --check

## Test manuali

- [ ] “My Garage” è più grande e visibile
- [ ] Navbar leggibile
- [ ] Colori più vivi ma non eccessivi
- [ ] Card dashboard leggibili
- [ ] Home desktop ok
- [ ] Home mobile ok
- [ ] Dark mode ok