### PR TITLE
Permette autenticazione cron con Bearer token

### DIFF
--- a/server/src/controllers/notificationController.js
+++ b/server/src/controllers/notificationController.js
@@ -116,7 +116,26 @@ function buildWeeklyEmailText({ user, alerts }) {
 
 function checkCronSecret(req, res) {
   const configuredSecret = process.env.INTERNAL_CRON_SECRET;
-  const requestSecret = req.get("x-cron-secret");
+const headerSecret = req.get("x-cron-secret");
+const authorizationHeader = req.get("authorization");
+
+const bearerSecret = authorizationHeader?.startsWith("Bearer ")
+  ? authorizationHeader.replace("Bearer ", "").trim()
+  : null;
+
+const requestSecret = headerSecret || bearerSecret;
+
+if (!configuredSecret) {
+  return res.status(500).json({
+    message: "INTERNAL_CRON_SECRET non configurato.",
+  });
+}
+
+if (!requestSecret || requestSecret !== configuredSecret) {
+  return res.status(401).json({
+    message: "Unauthorized",
+  });
+}
 
   if (!configuredSecret) {
     res.status(500).json({


### PR DESCRIPTION
## Riepilogo

- L’endpoint del cron settimanale ora accetta anche `Authorization: Bearer <secret>`
- Il supporto esistente a `x-cron-secret` rimane valido
- Migliora la compatibilità con servizi esterni come cron-job.org
- Nessuna modifica alla logica di invio email/notifiche

## Controlli eseguiti

- [x] npm --prefix client run build
- [x] git diff --check

## Test manuali da fare dopo deploy Render

- [ ] Test endpoint con `x-cron-secret`
- [ ] Test endpoint con `Authorization: Bearer <secret>`
- [ ] Test cron-job.org con metodo POST
- [ ] Verifica ricezione email/notifica